### PR TITLE
Force bash for sample.sh

### DIFF
--- a/quickstarts/file-api/sample.sh
+++ b/quickstarts/file-api/sample.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Upload a file using the GenAI File API via curl.
 api_key=""


### PR DESCRIPTION
The script uses bash-specific semantics (e.g. `[[`)  but does not force bash.

This causes silent partial-failures on terminals where /bin/sh is not bash.