### PR TITLE
Quote curl URLs

### DIFF
--- a/examples/Guess_the_shape.ipynb
+++ b/examples/Guess_the_shape.ipynb
@@ -78,9 +78,9 @@
       },
       "outputs": [],
       "source": [
-        "!curl -o triangle.png https://storage.googleapis.com/generativeai-downloads/images/triangle.png --silent\n",
-        "!curl -o square.png https://storage.googleapis.com/generativeai-downloads/images/square.png --silent\n",
-        "!curl -o pentagon.png https://storage.googleapis.com/generativeai-downloads/images/pentagon.png --silent"
+        "!curl -o triangle.png \"https://storage.googleapis.com/generativeai-downloads/images/triangle.png\" --silent\n",
+        "!curl -o square.png \"https://storage.googleapis.com/generativeai-downloads/images/square.png\" --silent\n",
+        "!curl -o pentagon.png \"https://storage.googleapis.com/generativeai-downloads/images/pentagon.png\" --silent"
       ]
     },
     {

--- a/quickstarts/Authentication.ipynb
+++ b/quickstarts/Authentication.ipynb
@@ -168,7 +168,7 @@
         "Or, if you're calling the API through your terminal using `cURL`, you can copy and paste this code to read your key from the environment variable.\n",
         "\n",
         "```\n",
-        "curl https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=$API_KEY \\\n",
+        "curl \"https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=$API_KEY\" \\\n",
         "    -H 'Content-Type: application/json' \\\n",
         "    -X POST \\\n",
         "    -d '{\n",

--- a/quickstarts/Counting_Tokens.ipynb
+++ b/quickstarts/Counting_Tokens.ipynb
@@ -346,7 +346,7 @@
       },
       "outputs": [],
       "source": [
-        "!curl -o jetpack.jpg https://storage.googleapis.com/generativeai-downloads/images/jetpack.jpg --silent"
+        "!curl -o jetpack.jpg \"https://storage.googleapis.com/generativeai-downloads/images/jetpack.jpg\" --silent"
       ]
     },
     {

--- a/quickstarts/File_API.ipynb
+++ b/quickstarts/File_API.ipynb
@@ -173,7 +173,7 @@
         }
       ],
       "source": [
-        "!curl -o image.jpg https://storage.googleapis.com/generativeai-downloads/images/jetpack.jpg\n",
+        "!curl -o image.jpg \"https://storage.googleapis.com/generativeai-downloads/images/jetpack.jpg\"\n",
         "Image(filename='image.jpg')"
       ]
     },

--- a/quickstarts/Prompting.ipynb
+++ b/quickstarts/Prompting.ipynb
@@ -164,7 +164,7 @@
         }
       ],
       "source": [
-        "!curl -o image.jpg https://storage.googleapis.com/generativeai-downloads/images/jetpack.jpg"
+        "!curl -o image.jpg \"https://storage.googleapis.com/generativeai-downloads/images/jetpack.jpg\""
       ]
     },
     {

--- a/quickstarts/rest/Embeddings_REST.ipynb
+++ b/quickstarts/rest/Embeddings_REST.ipynb
@@ -89,7 +89,7 @@
       "source": [
         "%%bash\n",
         "\n",
-        "curl https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:embedContent?key=$GOOGLE_API_KEY \\\n",
+        "curl \"https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:embedContent?key=$GOOGLE_API_KEY\" \\\n",
         "-H 'Content-Type: application/json' \\\n",
         "-d '{\"model\": \"models/text-embedding-004\",\n",
         "    \"content\": {\n",
@@ -158,7 +158,7 @@
       "source": [
         "%%bash\n",
         "\n",
-        "curl https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:batchEmbedContents?key=$GOOGLE_API_KEY \\\n",
+        "curl \"https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:batchEmbedContents?key=$GOOGLE_API_KEY\" \\\n",
         "-H 'Content-Type: application/json' \\\n",
         "-d '{\"requests\": [{\n",
         "      \"model\": \"models/text-embedding-004\",\n",
@@ -216,7 +216,7 @@
       "source": [
         "%%bash\n",
         "\n",
-        "curl https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:embedContent?key=$GOOGLE_API_KEY \\\n",
+        "curl \"https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:embedContent?key=$GOOGLE_API_KEY\" \\\n",
         "-H 'Content-Type: application/json' \\\n",
         "-d '{\"model\": \"models/text-embedding-004\",\n",
         "    \"output_dimensionality\":256,\n",
@@ -279,7 +279,7 @@
       "source": [
         "%%bash\n",
         "\n",
-        "curl https://generativelanguage.googleapis.com/v1beta/models/embedding-001:embedContent?key=$GOOGLE_API_KEY \\\n",
+        "curl \"https://generativelanguage.googleapis.com/v1beta/models/embedding-001:embedContent?key=$GOOGLE_API_KEY\" \\\n",
         "-H 'Content-Type: application/json' \\\n",
         "-d '{\"model\": \"models/text-embedding-004\",\n",
         "    \"content\": {\n",

--- a/quickstarts/rest/Function_calling_REST.ipynb
+++ b/quickstarts/rest/Function_calling_REST.ipynb
@@ -161,7 +161,7 @@
       "source": [
         "%%bash\n",
         "\n",
-        "curl https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=$GOOGLE_API_KEY \\\n",
+        "curl \"https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=$GOOGLE_API_KEY\" \\\n",
         "  -H 'Content-Type: application/json' \\\n",
         "  -d '{\n",
         "    \"contents\": {\n",
@@ -380,7 +380,7 @@
       "source": [
         "%%bash\n",
         "\n",
-        "curl https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=$GOOGLE_API_KEY \\\n",
+        "curl \"https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=$GOOGLE_API_KEY\" \\\n",
         "  -H 'Content-Type: application/json' \\\n",
         "  -d '{\n",
         "    \"contents\": [{\n",
@@ -553,7 +553,7 @@
       "source": [
         "%%bash\n",
         "\n",
-        "curl https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=$GOOGLE_API_KEY \\\n",
+        "curl \"https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=$GOOGLE_API_KEY\" \\\n",
         "  -H 'Content-Type: application/json' \\\n",
         "  -d '{\n",
         "    \"contents\": [{\n",

--- a/quickstarts/rest/JSON_mode_REST.ipynb
+++ b/quickstarts/rest/JSON_mode_REST.ipynb
@@ -89,7 +89,7 @@
       "source": [
         "%%bash\n",
         "\n",
-        "curl https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro-latest:generateContent?key=$GOOGLE_API_KEY \\\n",
+        "curl \"https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro-latest:generateContent?key=$GOOGLE_API_KEY\" \\\n",
         "-H 'Content-Type: application/json' \\\n",
         "-d '{\n",
         "    \"contents\": [{\n",

--- a/quickstarts/rest/Prompting_REST.ipynb
+++ b/quickstarts/rest/Prompting_REST.ipynb
@@ -137,7 +137,7 @@
       "source": [
         "%%bash\n",
         "\n",
-        "curl https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=$GOOGLE_API_KEY \\\n",
+        "curl \"https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=$GOOGLE_API_KEY\" \\\n",
         "    -H 'Content-Type: application/json' \\\n",
         "    -X POST \\\n",
         "    -d '{\n",
@@ -184,7 +184,7 @@
       "source": [
         "%%bash\n",
         "\n",
-        "curl -o image.jpg https://storage.googleapis.com/generativeai-downloads/images/jetpack.jpg"
+        "curl -o image.jpg \"https://storage.googleapis.com/generativeai-downloads/images/jetpack.jpg\""
       ]
     },
     {
@@ -275,7 +275,7 @@
       "source": [
         "%%bash\n",
         "\n",
-        "curl https://generativelanguage.googleapis.com/v1beta/models/gemini-pro-vision:generateContent?key=${GOOGLE_API_KEY} \\\n",
+        "curl \"https://generativelanguage.googleapis.com/v1beta/models/gemini-pro-vision:generateContent?key=${GOOGLE_API_KEY}\" \\\n",
         "        -H 'Content-Type: application/json' \\\n",
         "        -d @request.json"
       ],
@@ -372,7 +372,7 @@
       "cell_type": "markdown",
       "source": [
         "```\n",
-        "curl https://generativelanguage.googleapis.com/v1beta/models/gemini-pro-vision:generateContent?key=${GOOGLE_API_KEY} \\\n",
+        "curl \"https://generativelanguage.googleapis.com/v1beta/models/gemini-pro-vision:generateContent?key=${GOOGLE_API_KEY}\" \\\n",
         "        -H 'Content-Type: application/json' \\\n",
         "        -d '{\n",
         "  \"contents\":[\n",
@@ -482,7 +482,7 @@
       ],
       "source": [
         "%%bash\n",
-        "curl https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=$GOOGLE_API_KEY \\\n",
+        "curl \"https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=$GOOGLE_API_KEY\" \\\n",
         "    -H 'Content-Type: application/json' \\\n",
         "    -X POST \\\n",
         "    -d '{\n",
@@ -546,7 +546,7 @@
       "source": [
         "%%bash\n",
         "\n",
-        "curl https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=$GOOGLE_API_KEY \\\n",
+        "curl \"https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=$GOOGLE_API_KEY\" \\\n",
         "    -H 'Content-Type: application/json' \\\n",
         "    -X POST \\\n",
         "    -d '{\n",

--- a/quickstarts/rest/Safety_REST.ipynb
+++ b/quickstarts/rest/Safety_REST.ipynb
@@ -159,7 +159,7 @@
       "source": [
         "%%bash\n",
         "\n",
-        "curl https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=$GOOGLE_API_KEY \\\n",
+        "curl \"https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=$GOOGLE_API_KEY\" \\\n",
         "    -H 'Content-Type: application/json' \\\n",
         "    -X POST \\\n",
         "    -d @request.json  2> /dev/null | tee response.json"
@@ -232,7 +232,7 @@
       "source": [
         "%%bash\n",
         "\n",
-        "curl https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=$GOOGLE_API_KEY \\\n",
+        "curl \"https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=$GOOGLE_API_KEY\" \\\n",
         "    -H 'Content-Type: application/json' \\\n",
         "    -X POST \\\n",
         "    -d @request.json  2> /dev/null > response.json"

--- a/quickstarts/rest/System_instructions_REST.ipynb
+++ b/quickstarts/rest/System_instructions_REST.ipynb
@@ -122,7 +122,7 @@
       "source": [
         "%%bash\n",
         "\n",
-        "curl https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro-latest:generateContent?key=$GOOGLE_API_KEY \\\n",
+        "curl \"https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro-latest:generateContent?key=$GOOGLE_API_KEY\" \\\n",
         "-H 'Content-Type: application/json' \\\n",
         "-d '{ \"system_instruction\": {\n",
         "    \"parts\":\n",


### PR DESCRIPTION
Fixes issue #58 

To find all instances of curl that needed to be fixed, I  grepped regex `"!?curl\s+(-o\s+\S+\s+)?(https?://\S+)` and then added quotes to the 24 instances of unquoted curl URLs.

Please let me know if you think I missed a spot or if you think this is completely unnecessary. The referenced issue isn't really a bug, but rather an inconvenience for lazy zsh users like me. 
