### PR TITLE
Bug 67: Remove "Run in Colab" button for notebook that can't be run there

### DIFF
--- a/quickstarts/Streaming.ipynb
+++ b/quickstarts/Streaming.ipynb
@@ -12,19 +12,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "6e5f3f6c8c11"
-      },
-      "source": [
-        "<table align=\"left\">\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/google-gemini/cookbook/blob/main/quickstarts/Streaming.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
-        "  </td>\n",
-        "</table>\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "df1767a3d1cc"
       },
       "source": [
@@ -305,6 +292,10 @@
     "kernelspec": {
       "display_name": "Python 3",
       "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.11.7"
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
A quick and simple fix for bug #67 