### PR TITLE
add litellm example (OpenAI-Compatible Endpoint)

### DIFF
--- a/examples/Gemini_Pro_LiteLLM_(OpenAI_Compatible_Endpoint).ipynb
+++ b/examples/Gemini_Pro_LiteLLM_(OpenAI_Compatible_Endpoint).ipynb
@@ -1,0 +1,124 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# OpenAI-Compatible Endpoint\n",
+        "\n",
+        "Use [LiteLLM](https://github.com/BerriAI/litellm) to call Gemini in the OpenAI format. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "H--pem7MsUXl"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install litellm"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "xqKTu2-6scyt"
+      },
+      "source": [
+        "# Usage"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "eu3T_V3csZUo"
+      },
+      "outputs": [],
+      "source": [
+        "from litellm import completion\n",
+        "import os\n",
+        "\n",
+        "os.environ['GEMINI_API_KEY'] = \"\"\n",
+        "response = completion(\n",
+        "    model=\"gemini/gemini-pro\",\n",
+        "    messages=[{\"role\": \"user\", \"content\": \"write code for saying hi from LiteLLM\"}]\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "fO1R-hDCsdsd"
+      },
+      "source": [
+        "# Vision"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "-ZpcBIknsgyh"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "import litellm\n",
+        "from dotenv import load_dotenv\n",
+        "\n",
+        "# Load the environment variables from .env file\n",
+        "load_dotenv()\n",
+        "os.environ[\"GEMINI_API_KEY\"] = os.getenv('GEMINI_API_KEY')\n",
+        "\n",
+        "prompt = 'Describe the image in a few sentences.'\n",
+        "# Note: You can pass here the URL or Path of image directly.\n",
+        "image_url = 'https://storage.googleapis.com/github-repo/img/gemini/intro/landmark3.jpg'\n",
+        "\n",
+        "# Create the messages payload according to the documentation\n",
+        "messages = [\n",
+        "    {\n",
+        "        \"role\": \"user\",\n",
+        "        \"content\": [\n",
+        "            {\n",
+        "                \"type\": \"text\",\n",
+        "                \"text\": prompt\n",
+        "            },\n",
+        "            {\n",
+        "                \"type\": \"image_url\",\n",
+        "                \"image_url\": {\"url\": image_url}\n",
+        "            }\n",
+        "        ]\n",
+        "    }\n",
+        "]\n",
+        "\n",
+        "# Make the API call to Gemini model\n",
+        "response = litellm.completion(\n",
+        "    model=\"gemini/gemini-pro-vision\",\n",
+        "    messages=messages,\n",
+        ")\n",
+        "\n",
+        "# Extract the response content\n",
+        "content = response.get('choices', [{}])[0].get('message', {}).get('content')\n",
+        "\n",
+        "# Print the result\n",
+        "print(content)"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}


### PR DESCRIPTION
Hi @random-forests @markmcd,

Adding a tutorial to show how to call Gemini through an OpenAI-Compatible Endpoint (via [LiteLLM](https://github.com/BerriAI/litellm))

This supports Google AI Studio + Vertex AI as well. 


Let me know if there's anything further required here! 