### PR TITLE
Add colab button and h1 prefix to FCC recipe

### DIFF
--- a/quickstarts/Function_calling_config.ipynb
+++ b/quickstarts/Function_calling_config.ipynb
@@ -8,13 +8,16 @@
       "source": [
         "# Gemini API: Function calling config\n",
         "\n",
-        "<link href=\"https://ai.google.dev/site-assets/css/style.css\" rel=\"stylesheet\"/>\n",
-        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "<table>\n",
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/google-gemini/cookbook/blob/main/quickstarts/Function_calling_config.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
         "  </td>\n",
-        "</table>",
-        "\n",
+        "</table>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
         "Specifying a `function_calling_config` allows you to control how the Gemini API acts when `tools` have been specified. For example, you can choose to only allow free-text output (disabling function calling), force it to choose from a subset of the functions provided in `tools`, or let it act automatically.\n",
         "\n",
         "This guide assumes you are already familiar with function calling. For an introduction, check out the [docs](https://ai.google.dev/docs/function_calling)."

--- a/quickstarts/Function_calling_config.ipynb
+++ b/quickstarts/Function_calling_config.ipynb
@@ -17,6 +17,9 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "1e41a2ce62eb"
+      },
       "source": [
         "Specifying a `function_calling_config` allows you to control how the Gemini API acts when `tools` have been specified. For example, you can choose to only allow free-text output (disabling function calling), force it to choose from a subset of the functions provided in `tools`, or let it act automatically.\n",
         "\n",

--- a/quickstarts/Function_calling_config.ipynb
+++ b/quickstarts/Function_calling_config.ipynb
@@ -8,7 +8,7 @@
       "source": [
         "# Gemini API: Function calling config\n",
         "\n",
-        "<table>\n",
+        "<table align=\"left\">\n",
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/google-gemini/cookbook/blob/main/quickstarts/Function_calling_config.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
         "  </td>\n",

--- a/quickstarts/Function_calling_config.ipynb
+++ b/quickstarts/Function_calling_config.ipynb
@@ -6,7 +6,14 @@
         "id": "IDS9Xcj_8k-T"
       },
       "source": [
-        "# Function calling config\n",
+        "# Gemini API: Function calling config\n",
+        "\n",
+        "<link href=\"https://ai.google.dev/site-assets/css/style.css\" rel=\"stylesheet\"/>\n",
+        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/google-gemini/cookbook/blob/main/quickstarts/Function_calling_config.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "</table>",
         "\n",
         "Specifying a `function_calling_config` allows you to control how the Gemini API acts when `tools` have been specified. For example, you can choose to only allow free-text output (disabling function calling), force it to choose from a subset of the functions provided in `tools`, or let it act automatically.\n",
         "\n",


### PR DESCRIPTION
Adds `Gemini API: ` prefix and "Run in Google Colab" button.