### PR TITLE
Update Authentication_with_OAuth.ipynb

### DIFF
--- a/quickstarts/Authentication_with_OAuth.ipynb
+++ b/quickstarts/Authentication_with_OAuth.ipynb
@@ -228,7 +228,7 @@
       "source": [
         "!gcloud auth application-default login \\\n",
         "  --no-browser --client-id-file client_secret.json \\\n",
-        "  --scopes='https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/generative-language.tuning,https://www.googleapis.com/auth/generative-language.retriever'\n"
+        "  --scopes https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/generative-language.tuning,https://www.googleapis.com/auth/generative-language.retriever\n"
       ]
     },
     {

--- a/quickstarts/Authentication_with_OAuth.ipynb
+++ b/quickstarts/Authentication_with_OAuth.ipynb
@@ -156,7 +156,7 @@
       "source": [
         "## Set up application default credentials\n",
         "\n",
-        "In this quickstart we use [application default credentials](https://cloud.google.com/docs/authentication/application-default-credentials) to authenticate."
+        "In this quickstart you will use [application default credentials](https://cloud.google.com/docs/authentication/application-default-credentials) to authenticate."
       ]
     },
     {
@@ -237,7 +237,7 @@
         "id": "TWTBztxTRYb5"
       },
       "source": [
-        "The specific `scopes` you need depends on the API you are using. For example, looking at the API reference for [`tunedModels.create`](https://ai.google.dev/api/rest/v1beta/tunedModels/create#authorization-scopes) we see:\n",
+        "The specific `scopes` you need depends on the API you are using. For example, looking at the API reference for [`tunedModels.create`](https://ai.google.dev/api/rest/v1beta/tunedModels/create#authorization-scopes), you will see:\n",
         "\n",
         "> Requires one of the following OAuth scopes:\n",
         ">\n",
@@ -285,7 +285,7 @@
         "id": "r8GgGmTrUCR2"
       },
       "source": [
-        "Let's do a quick test. Note that we did not set an API key using `genai.configure()`!"
+        "Let's do a quick test. Note that you did not set an API key using `genai.configure()`!"
       ]
     },
     {
@@ -318,7 +318,7 @@
       "source": [
         "## Making authenticated REST calls from Colab\n",
         "\n",
-        "In general, we recommend using the Python SDK to interact with the Gemini API when possible. This example shows how to make OAuth authenticated REST calls from Python for debugging or testing purposes. It assumes you have already set application default credentials from the Quickstart."
+        "In general, you should use the Python SDK to interact with the Gemini API when possible. This example shows how to make OAuth authenticated REST calls from Python for debugging or testing purposes. It assumes you have already set application default credentials from the Quickstart."
       ]
     },
     {


### PR DESCRIPTION
The equal sign after --scopes and the single quotes before the urls were being interpreted as part of the first scope URL. The last single quote was being interpreted as part of the third scope URL.

This caused a 400 error with the message "Some scopes invalid" and prevented sign in. Running the command without the = or ' was successful.