### PR TITLE
The "pip install -U -q google.generativeai" should change to "pip install -U -q google-generativeai" for consistency

### DIFF
--- a/examples/Anomaly_detection_with_embeddings.ipynb
+++ b/examples/Anomaly_detection_with_embeddings.ipynb
@@ -83,7 +83,7 @@
         }
       ],
       "source": [
-        "!pip install -U -q google.generativeai"
+        "!pip install -U -q google-generativeai"
       ]
     },
     {

--- a/examples/Classify_text_with_embeddings.ipynb
+++ b/examples/Classify_text_with_embeddings.ipynb
@@ -84,7 +84,7 @@
         }
       ],
       "source": [
-        "!pip install -U -q google.generativeai"
+        "!pip install -U -q google-generativeai"
       ]
     },
     {

--- a/examples/Search_Wikipedia_using_ReAct.ipynb
+++ b/examples/Search_Wikipedia_using_ReAct.ipynb
@@ -124,7 +124,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install -q google.generativeai"
+        "!pip install -q google-generativeai"
       ]
     },
     {

--- a/examples/Talk_to_documents_with_embeddings.ipynb
+++ b/examples/Talk_to_documents_with_embeddings.ipynb
@@ -83,7 +83,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install -U -q google.generativeai"
+        "!pip install -U -q google-generativeai"
       ]
     },
     {

--- a/quickstarts/Models.ipynb
+++ b/quickstarts/Models.ipynb
@@ -70,7 +70,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install -U -q google.generativeai"
+        "!pip install -U -q google-generativeai"
       ]
     },
     {

--- a/quickstarts/Prompting.ipynb
+++ b/quickstarts/Prompting.ipynb
@@ -74,7 +74,7 @@
         }
       ],
       "source": [
-        "!pip install -U -q google.generativeai # Install the Python SDK"
+        "!pip install -U -q google-generativeai # Install the Python SDK"
       ]
     },
     {


### PR DESCRIPTION
There are some documents write this way:

```sh
pip install -U -q google.generativeai
```

and some others are write this way:

```sh
pip install -U -q google-generativeai
```

I just references from here: https://ai.google.dev/api/python/google/generativeai

The package name should be consistent. So I updated it to `google-generativeai`.