### PR TITLE
Add examples/CONTRIBUTING.md

### DIFF
--- a/examples/CONTRIBUTING.md
+++ b/examples/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing to the Cookbook examples
+
+For our general contribution policy, please see our top-level [contributors guide](../CONTRIBUTING.md).
+
+## Policy on new examples
+
+Whether we accept a contribution will depend on its utility and what it demonstrates. Above all, any contribution needs to demonstrate something unique that a Gemini API developer wants to see.
+
+The cookbook currently only accepts English Python and REST content directly, but we are happy to link out to other content if it’s suitable.
+
+Before writing anything, [file an issue](https://github.com/google-gemini/cookbook/issues/new) describing what you want to contribute. Include:
+
+* Whether this is a “pure” Gemini API example or a third-party integration example.  
+  * If pure:
+    * Describe the use case and why it’s useful to developers (e.g. link to the underlying paper).
+  * If non-pure:
+    * Describe the integration(s) and why they are important.
+    * Link to the GitHub repository, package, or equivalent \- we will use information like the number of downloads or stars to determine the utility of the integration
+
+* A high-level outline of what you will write.
+
+* Any support you need.  
+  * For example, if you are worried that your English is not good enough, please call that out here. We are an inclusive community and will work with you to meet our high publication standards if your proposal is otherwise accepted.
+
+All contributions must also adhere to the Gemini API's [terms of service](https://ai.google.dev/gemini-api/terms).
+
+Googlers, for more information see go/gemini-cookbook-policy.


### PR DESCRIPTION
This doc serves to invite users to contribute examples, while also setting some guidelines around what we will accept.