### PR TITLE
Add a template notebook.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,9 @@ Before you send a PR, or even write a single line, please file an [issue](https:
 
 Adding a new guide often involves lots of detailed reviews and we want to make sure that your idea is fully formed and has full support before you start writing anything. If you want to port an existing guide across (e.g. if you have a guide for Gemini on your own GitHub), feel free to link to it in the issue.
 
+When you're ready, start by using the [notebook
+template](./templates/Template.ipynb) and following the guidance within.
+
 ## Things we consider
 
 When accepting a new guide, we want to balance a few aspects.

--- a/examples/CONTRIBUTING.md
+++ b/examples/CONTRIBUTING.md
@@ -10,7 +10,7 @@ The cookbook currently only accepts English Python and REST content directly, bu
 
 Before writing anything, [file an issue](https://github.com/google-gemini/cookbook/issues/new) describing what you want to contribute. Include:
 
-* Whether this is a “pure” Gemini API example or a third-party integration example.  
+* Whether this is a “pure” Gemini API example or a third-party integration example.
   * If pure:
     * Describe the use case and why it’s useful to developers (e.g. link to the underlying paper).
   * If non-pure:
@@ -19,8 +19,11 @@ Before writing anything, [file an issue](https://github.com/google-gemini/cookbo
 
 * A high-level outline of what you will write.
 
-* Any support you need.  
+* Any support you need.
   * For example, if you are worried that your English is not good enough, please call that out here. We are an inclusive community and will work with you to meet our high publication standards if your proposal is otherwise accepted.
+
+When you're ready to start writing, make a copy of the [notebook
+template](./templates/Template.ipynb) and follow the guidance within.
 
 All contributions must also adhere to the Gemini API's [terms of service](https://ai.google.dev/gemini-api/terms).
 

--- a/templates/Template.ipynb
+++ b/templates/Template.ipynb
@@ -1,0 +1,232 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Tce3stUlHN0L"
+      },
+      "source": [
+        "##### Copyright 2024 Google LLC."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "tuOe1ymfHZPu"
+      },
+      "outputs": [],
+      "source": [
+        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "# https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "qFdPvlXBOdUN"
+      },
+      "source": [
+        "# Gemini API: Name of your guide"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "MfBg1C5NB3X0"
+      },
+      "source": [
+        "<table align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/google-gemini/cookbook/blob/main/templates/Template.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "</table>\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "r6P32iYYV27b"
+      },
+      "source": [
+        "_[remove me] Be sure to update the Colab link!_"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "xHxb-dlhMIzW"
+      },
+      "source": [
+        "[Include a paragraph or two here explaining what this example demonstrates, who should be interested in it, and what you need to know before you get started.]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "AQJjzmYgH3sX"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install -U -q google-generativeai  # Install the Python SDK\n",
+        "\n",
+        "# If you are relying on a new feature, be sure to include the minimum\n",
+        "# SDK version here too - e.g. 'google-generativeai>=0.9.9'."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "iQSKjF5WH5N9"
+      },
+      "outputs": [],
+      "source": [
+        "import google.generativeai as genai"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "MUXex9ctTuDB"
+      },
+      "source": [
+        "## Set up your API key\n",
+        "\n",
+        "To run the following cell, your API key must be stored it in a Colab Secret named `GOOGLE_API_KEY`. If you don't already have an API key, or you're not sure how to create a Colab Secret, see the [Authentication](https://github.com/google-gemini/cookbook/blob/main/quickstarts/Authentication.ipynb) quickstart for an example."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "wltbMJLIIXGk"
+      },
+      "outputs": [],
+      "source": [
+        "from google.colab import userdata\n",
+        "\n",
+        "GOOGLE_API_KEY = userdata.get(\"GOOGLE_API_KEY\")\n",
+        "genai.configure(api_key=GOOGLE_API_KEY)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "w5i8tMZKIeUu"
+      },
+      "source": [
+        "## [Write your guide]\n",
+        "\n",
+        "[Add as many high level sections as needed to step through your guide. Try to introduce new concepts incrementally, and remember that notebooks need to be executable from start to finish using `Runtime -> Run all` in Colab.]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "UhNtHfuxCGVy"
+      },
+      "source": [
+        "## Resources\n",
+        "\n",
+        "* Follow the [Google developer documentation style guide](https://developers.google.com/style/highlights)\n",
+        "* The [TensorFlow documentation style guide](https://www.tensorflow.org/community/contribute/docs_style) has useful guidance for notebooks.\n",
+        "* Read the [Cookbook contributor guide](https://github.com/google-gemini/cookbook/blob/main/CONTRIBUTING.md) and the [Cookbook Examples contributor guide](https://github.com/google-gemini/cookbook/blob/main/examples/CONTRIBUTING.md)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "2V22fKegUtF9"
+      },
+      "source": [
+        "## Notebook style\n",
+        "\n",
+        "* Include the collapsed license at the top (uses the Colab \"Form\" mode to hide the cells).\n",
+        "* Save the notebook with the table of contents open.\n",
+        "* Use one `H1` header for the title.\n",
+        "* Include the button-bar immediately after the `H1`.\n",
+        "* Include an overview section before any code.\n",
+        "* Put all your installs and imports in a setup section.\n",
+        "* Keep code and text cells as brief as possible.\n",
+        "* Break text cells at headings\n",
+        "* Break code cells between \"building\" and \"running\", and between \"printing one result\" and \"printing another result\".\n",
+        "* Necessary but uninteresting code should be hidden in a toggleable code cell by putting `# @title` as the first line."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "QKp40qS-DGEZ"
+      },
+      "source": [
+        "### Code style\n",
+        "\n",
+        "* Notebooks are for people. Write code optimized for clarity.\n",
+        "* Keep examples quick and concise.\n",
+        "* Use the [Google Python Style Guide](http://google.github.io/styleguide/pyguide.html), where applicable. Code formatted by [`pyink`](https://github.com/google/pyink) will always be accepted.\n",
+        "* If you define a function, run it and show us what it does before using it in another function.\n",
+        "* Demonstrate small parts before combining them into something more complex.\n",
+        "* To ensure notebook text remains accurate, present model metadata by executing code.\n",
+        "  * For example, instead of saying \"1M token context\" in the text, display the output of `genai.get_model('models/...').input_token_limit`.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "78HBT9cQXJko"
+      },
+      "source": [
+        "### Text\n",
+        "\n",
+        "* Use an imperative style. \"Run a prompt using the API.\"\n",
+        "* Use sentence case in titles/headings.\n",
+        "* Use short titles/headings: \"Download the data\", \"Call the API\", \"Process the results\".\n",
+        "* Use the [Google developer documentation style guide](https://developers.google.com/style/highlights).\n",
+        "* Use [second person](https://developers.google.com/style/person): \"you\" rather than \"we\".\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "YrsKXcPRUvK9"
+      },
+      "source": [
+        "## GitHub workflow\n",
+        "\n",
+        "* Be consistent about how you save your notebooks, otherwise the JSON diffs are messy. [`nbfmt` and `nblint`](https://github.com/tensorflow/docs/blob/master/tools/tensorflow_docs/tools/README.md) help here.\n",
+        "* This notebook has the \"Omit code cell output when saving this notebook\" option set. GitHub refuses to diff notebooks with large diffs (inline images).\n",
+        "* [ReviewNB.com](http://reviewnb.com) can help with diffs. This is linked in a comment on a notebook pull request.\n",
+        "* Use the [Open in Colab](https://chrome.google.com/webstore/detail/open-in-colab/iogfkhleblhcpcekbiedikdehleodpjo) extension to open a GitHub notebook in Colab.\n",
+        "* The easiest way to edit a notebook in GitHub is to open it with Colab from the branch you want to edit. Then use File --> Save a copy in GitHub, which will save it back to the branch you opened it from.\n",
+        "* For PRs it's helpful to post a direct Colab link to the PR head: https://colab.research.google.com/github/{USER}/{REPO}/blob/{BRANCH}/{PATH}.ipynb"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "collapsed_sections": [
+        "Tce3stUlHN0L"
+      ],
+      "name": "Template.ipynb",
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}


### PR DESCRIPTION
This is for new contributors or Googlers to use as a base for new quickstarts or examples.

It's largely forked from the [TensorFlow template](https://github.com/tensorflow/docs/blob/master/tools/templates/notebook.ipynb), but I've updated the guidance to apply to the Gemini API and this cookbook.