### PR TITLE
Remove bad reference to Pro model.

### DIFF
--- a/quickstarts/Video.ipynb
+++ b/quickstarts/Video.ipynb
@@ -59,7 +59,7 @@
         "id": "q7QvXQMrIhuZ"
       },
       "source": [
-        "This notebook provides a quick example of how to prompt Gemini 1.5 Pro using a video file. In this case, you'll use a short clip of [Big Buck Bunny](https://peach.blender.org/about/)."
+        "This notebook provides a quick example of how to prompt the Gemini API using a video file. In this case, you'll use a short clip of [Big Buck Bunny](https://peach.blender.org/about/)."
       ]
     },
     {


### PR DESCRIPTION
This example uses the Flash model, but the intro text says Pro. Updated to be generic.