### PR TITLE
Fix environment variable for API key used in cURL example

### DIFF
--- a/quickstarts/Authentication.ipynb
+++ b/quickstarts/Authentication.ipynb
@@ -265,7 +265,7 @@
         "Or, if you're calling the API through your terminal using `cURL`, you can copy and paste this code to read your key from the environment variable.\n",
         "\n",
         "```\n",
-        "curl \"https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=$API_KEY\" \\\n",
+        "curl \"https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=$GOOGLE_API_KEY\" \\\n",
         "    -H 'Content-Type: application/json' \\\n",
         "    -X POST \\\n",
         "    -d '{\n",


### PR DESCRIPTION
For terminal usage, the environment variable passed to cURL doesn’t match that exported above, changing to GOOGLE_API_KEY resolves this.