### PR TITLE
Close stale issues/PRs after 13 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,8 +7,8 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-  # Scheduled to run at 1.30 UTC everyday
-  - cron: '30 1 * * *'
+  # Scheduled to run at 10.30PM UTC everyday (1530PDT/1430PST)
+  - cron: '30 22 * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-issue-stale: 14
-        days-before-issue-close: 14
+        days-before-issue-close: 13
         stale-issue-label: "status:stale"
         close-issue-reason: not_planned
         any-of-labels: "status:awaiting response,status:more data needed"
@@ -32,16 +32,16 @@ jobs:
           Marking this issue as stale since it has been open for 14 days with no activity.
           This issue will be closed if no further activity occurs.
         close-issue-message: >
-          This issue was closed because it has been inactive for 28 days.
+          This issue was closed because it has been inactive for 27 days.
           Please post a new issue if you need further assistance. Thanks!
         days-before-pr-stale: 14
-        days-before-pr-close: 14
+        days-before-pr-close: 13
         stale-pr-label: "status:stale"
         stale-pr-message: >
           Marking this pull request as stale since it has been open for 14 days with no activity.
           This PR will be closed if no further activity occurs.
         close-pr-message: >
-          This pull request was closed because it has been inactive for 28 days.
+          This pull request was closed because it has been inactive for 27 days.
           Please open a new pull request if you need further assistance. Thanks!
         # Label that can be assigned to issues to exclude them from being marked as stale
         exempt-issue-labels: 'override-stale'


### PR DESCRIPTION
As discussed, reducing the close date to 13 days so we can review fortnightly. Also updated the scheduled time so it runs before our current meeting schedule.

I left the initial reminder to 14 days as I think the closure is the key event, but lmk if you think we should do both.