### PR TITLE
Add an async quickstart

### DIFF
--- a/quickstarts/Asynchronous_requests.ipynb
+++ b/quickstarts/Asynchronous_requests.ipynb
@@ -1,0 +1,349 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "YuXYZBmuHYxa"
+      },
+      "source": [
+        "##### Copyright 2024 Google LLC."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "Q2fjiWA5HetI"
+      },
+      "outputs": [],
+      "source": [
+        "# @title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "# https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "juLxdbNPIiPF"
+      },
+      "source": [
+        "# Gemini API: Asynchronous Python requests\n",
+        "\n",
+        "<table align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/google-gemini/cookbook/blob/main/quickstarts/Asynchronous_requests.ipynb\"><img src=\"../images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "</table>\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dBfCOtXROsVR"
+      },
+      "source": [
+        "This notebook will show you how to make asynchronous and parallel requests using the Gemini API's Python SDK and Python 3's [`asyncio`](https://docs.python.org/3/library/asyncio.html) standard library.\n",
+        "\n",
+        "The examples here run in Google Colab and use the implicit event loop supplied in Colab. You can also run these commands interactively using the `asyncio` REPL (invoked with `python -m asyncio`), or you can manage the [event loop](https://docs.python.org/3/library/asyncio-eventloop.html) yourself."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "CUCIiuo60vgI"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install -qU 'google-generativeai>=0.8.3' aiohttp"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "xuqMdClt-7Jp"
+      },
+      "outputs": [],
+      "source": [
+        "import aiohttp\n",
+        "import asyncio\n",
+        "import io\n",
+        "import PIL\n",
+        "import google.generativeai as genai"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "qRvMY4eb_h8j"
+      },
+      "outputs": [],
+      "source": [
+        "# This notebook should work fine in a normal Python environment, but due to https://github.com/google-gemini/generative-ai-python/issues/499\n",
+        "# this workaround is needed in Colab, effectively un-monkey-patching a Colab patch.\n",
+        "genai.configure = getattr(genai.configure, \"func\", genai.configure)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "g1GCRqAyDOpz"
+      },
+      "source": [
+        "## Set up your API key\n",
+        "\n",
+        "To run the following cell, your API key must be stored it in a Colab Secret named `GOOGLE_API_KEY`. If you don't already have an API key, or you're not sure how to create a Colab Secret, see the [Authentication](../quickstarts/Authentication.ipynb) quickstart for an example."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "JiXbEhpl_0ya"
+      },
+      "outputs": [],
+      "source": [
+        "from google.colab import userdata\n",
+        "\n",
+        "GOOGLE_API_KEY = userdata.get(\"GOOGLE_API_KEY\")\n",
+        "genai.configure(api_key=GOOGLE_API_KEY)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "vtOfRg-UFSuB"
+      },
+      "source": [
+        "## Using local files\n",
+        "\n",
+        "This simple example shows how can you use local files (presumed to load quickly) with the SDK's `async` API."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "D1Sw3UzEFekL"
+      },
+      "outputs": [],
+      "source": [
+        "model = genai.GenerativeModel(\"gemini-1.5-flash-latest\")\n",
+        "\n",
+        "prompt = \"Describe this image in just 3 words.\"\n",
+        "\n",
+        "img_filenames = [\"firefighter.jpg\", \"elephants.jpeg\", \"jetpack.jpg\"]\n",
+        "img_dir = \"https://storage.googleapis.com/generativeai-downloads/images/\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "w0NBs55iFwyR"
+      },
+      "source": [
+        "Start by downloading the files locally."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "iRGHeraNFwTL"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "2024-10-18 01:00:43 URL:https://storage.googleapis.com/generativeai-downloads/images/firefighter.jpg [547369/547369] -> \"firefighter.jpg.2\" [1]\n",
+            "2024-10-18 01:00:43 URL:https://storage.googleapis.com/generativeai-downloads/images/elephants.jpeg [224007/224007] -> \"elephants.jpeg.2\" [1]\n",
+            "2024-10-18 01:00:43 URL:https://storage.googleapis.com/generativeai-downloads/images/jetpack.jpg [357568/357568] -> \"jetpack.jpg.2\" [1]\n",
+            "FINISHED --2024-10-18 01:00:43--\n",
+            "Total wall clock time: 0.1s\n",
+            "Downloaded: 3 files, 1.1M in 0.01s (83.7 MB/s)\n"
+          ]
+        }
+      ],
+      "source": [
+        "!wget -nv {img_dir}{{{','.join(img_filenames)}}}"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "AyUIpSnnJD4W"
+      },
+      "source": [
+        "The async code uses the `generate_content_async` method to invoke the API. Most API methods have an `_async` variant that provides this functionality.\n",
+        "\n",
+        "Note that this code is not run in parallel. The async call indicates that the event loop *can* yield to other tasks, but there are no other tasks scheduled in this code. This may be sufficient, e.g. if you are running this in a web server request handler as it will allow the handler to yield to other tasks while waiting for the API response."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "AXcB_yPGFlZd"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Cat in a tree. \n",
+            "\n",
+            "Elephants in grass. \n",
+            "\n",
+            "Jetpack Backpack \n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "async def describe_local_images():\n",
+        "\n",
+        "  for img_filename in img_filenames:\n",
+        "\n",
+        "    img = PIL.Image.open(img_filename)\n",
+        "    r = await model.generate_content_async([prompt, img])\n",
+        "    print(r.text)\n",
+        "\n",
+        "\n",
+        "await describe_local_images()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Zg4Ki_vKRpV1"
+      },
+      "source": [
+        "## Downloading images asynchronously and in parallel\n",
+        "\n",
+        "This example shows a more real-world case where an image is downloaded from an external source using the async HTTP library [`aiohttp`](https://pypi.org/project/aiohttp), and each image is processed in parallel."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "RdykoS-G__Tv"
+      },
+      "outputs": [],
+      "source": [
+        "async def download_image(session: aiohttp.ClientSession, img_url: str) -> PIL.Image:\n",
+        "  \"\"\"Returns a PIL.Image object from the provided URL.\"\"\"\n",
+        "  async with session.get(img_url) as img_resp:\n",
+        "    buffer = io.BytesIO()\n",
+        "    buffer.write(await img_resp.read())\n",
+        "    return PIL.Image.open(buffer)\n",
+        "\n",
+        "\n",
+        "async def process_image(img_future: asyncio.Future[PIL.Image]) -> str:\n",
+        "  \"\"\"Summarise the image using the Gemini API.\"\"\"\n",
+        "  # This code uses a future so that it defers work as late as possible. Using a\n",
+        "  # concrete Image object would require awaiting the download task before *queueing*\n",
+        "  # this content generation task - this approach chains the futures together\n",
+        "  # so that the download only starts when the generation is scheduled.\n",
+        "  r = await model.generate_content_async([prompt, await img_future])\n",
+        "  return r.text"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "447qlmtD2kWe"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Download and content generation queued for 3 images.\n",
+            "\n",
+            "Cat in tree. \n",
+            "\n",
+            "\n",
+            "Elephant Family Grass\n",
+            "\n",
+            "Jetpack Backpack \n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "async def download_and_describe():\n",
+        "\n",
+        "  async with aiohttp.ClientSession() as sesh:\n",
+        "    response_futures = []\n",
+        "    for img_filename in img_filenames:\n",
+        "\n",
+        "      # Create the image download tasks (this does not schedule them yet).\n",
+        "      img_future = download_image(sesh, img_dir + img_filename)\n",
+        "\n",
+        "      # Kick off the Gemini API request using the pending image download tasks.\n",
+        "      text_future = process_image(img_future)\n",
+        "\n",
+        "      # Save the reference so they can be processed as they complete.\n",
+        "      response_futures.append(text_future)\n",
+        "\n",
+        "    print(f\"Download and content generation queued for {len(response_futures)} images.\")\n",
+        "\n",
+        "    # Process responses as they complete (may be a different order). The tasks are started here.\n",
+        "    for response in asyncio.as_completed(response_futures):\n",
+        "      print()\n",
+        "      print(await response)\n",
+        "\n",
+        "\n",
+        "await download_and_describe()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "QOU0_lELKKFG"
+      },
+      "source": [
+        "In the above example, a coroutine is created for each image that both downloads and then summarizes the image. The coroutines are executed in the final step, in the `as_completed` loop. To start them as early as possible without blocking the other work, you could wrap `download_image` in [`asyncio.ensure_future`](https://docs.python.org/3/library/asyncio-future.html#asyncio.ensure_future), but for this example the execution has been deferred to keep the creation and execution concerns separate."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-uAy7qOkOGHi"
+      },
+      "source": [
+        "## Next Steps\n",
+        "\n",
+        "* Check out the `*_async` methods on the [`GenerativeModel`](https://github.com/google-gemini/generative-ai-python/blob/main/docs/api/google/generativeai/GenerativeModel.md) class in the Python SDK reference.\n",
+        "* Read more on Python's [`asyncio`](https://docs.python.org/3/library/asyncio.html) library"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "name": "Asynchronous_requests.ipynb",
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/quickstarts/README.md
+++ b/quickstarts/README.md
@@ -2,6 +2,7 @@
 
 ## Table of contents
 Learn about the capabilities of the Gemini API by checking out these quickstarts. They walk you through how to use a feature of the Gemini API with complete end to end code.
+* [Asynchronous requests](https://github.com/google-gemini/cookbook/blob/main/quickstarts/Asynchronous_requests.ipynb): Learn how to use Python's async/await API with the Gemini SDK to parallelize calls.
 * [Authentication](https://github.com/google-gemini/cookbook/blob/main/quickstarts/Authentication.ipynb): Start here to learn how you can set up your API key so you can get access to the Gemini API.
 * [Counting Tokens](https://github.com/google-gemini/cookbook/blob/main/quickstarts/Counting_Tokens.ipynb) Tokens are the basic inputs to the Gemini models. Through this notebook, you will gain a better understanding of tokens through an interactive experience.
 * [Gemini Flash Introduction](https://github.com/google-gemini/cookbook/blob/main/quickstarts/Gemini_Flash_Introduction.ipynb): Get started with Gemini Flash 1.5.
@@ -18,4 +19,4 @@ Learn about the capabilities of the Gemini API by checking out these quickstarts
 * [Tuning](https://github.com/google-gemini/cookbook/blob/main/quickstarts/Tuning.ipynb): Learn how to improve model performance on a specific task through tuning.
 * [Video](https://github.com/google-gemini/cookbook/blob/main/quickstarts/Video.ipynb): Upload a video to the Gemini API and use it in your prompt.
 
-When you're finished here, check out the [examples folder](https://github.com/google-gemini/cookbook/tree/main/examples) or the [Awesome Gemini page](../Awesome_gemini.md) for more fun examples.  
+When you're finished here, check out the [examples folder](https://github.com/google-gemini/cookbook/tree/main/examples) or the [Awesome Gemini page](../Awesome_gemini.md) for more fun examples.


### PR DESCRIPTION
This is a Python-only quickstart that shows how to use the SDK's `async` API.

I've included two examples, one as the "simplest possible" case that assumes the files are available locally and a more complex example that schedules in parallel and includes a download step using a shared HTTP session.