### PR TITLE
Add missing permission to stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,6 +18,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+      actions: write
 
     steps:
     - uses: actions/stale@v9


### PR DESCRIPTION
I think this is causing issues with the stale issues cache, so some issues/PRs are not being processed.