### PR TITLE
Fix: Convert BGR to RGB color space for correct video colors

### DIFF
--- a/gemini-2/websockets/live_api_starter.py
+++ b/gemini-2/websockets/live_api_starter.py
@@ -83,7 +83,11 @@ class AudioLoop:
         if not ret:
             return None
 
-        img = PIL.Image.fromarray(frame)
+        # Fix: Convert BGR to RGB color space
+        # OpenCV captures in BGR but PIL expects RGB format
+        # This prevents the blue tint in the video feed
+        frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        img = PIL.Image.fromarray(frame_rgb)  # Now using RGB frame
         img.thumbnail([1024, 1024])
 
         image_io = io.BytesIO()


### PR DESCRIPTION
# Video Feed Color Correction

## Issue
- Video feed shows blue tint due to BGR/RGB colorspace mismatch between OpenCV and PIL
- OpenCV captures in BGR format while PIL expects RGB

## Fix
- Added cv2.cvtColor conversion before PIL processing
- Converts OpenCV's BGR output to RGB before PIL processing
- Added explanatory comments for future maintainers

## Testing
- Tested with live video feed
- Confirms correct color reproduction without blue tint
- No impact on performance or other functionality

## Technical Details
- Modified _get_frame method to include color space conversion
- Uses cv2.COLOR_BGR2RGB for correct color mapping
- Maintains existing image processing pipeline