### PR TITLE
Updating prompt to request a single cookie recipe

### DIFF
--- a/gemini-2/get_started.ipynb
+++ b/gemini-2/get_started.ipynb
@@ -748,7 +748,7 @@
         "\n",
         "response = client.models.generate_content(\n",
         "    model=MODEL_ID,\n",
-        "    contents=\"List 3 popular cookie recipes and their ingredients.\",\n",
+        "    contents=\"Provide a popular cookie recipe and its ingredients.\",\n",
         "    config=types.GenerateContentConfig(\n",
         "        response_mime_type=\"application/json\",\n",
         "        response_schema=Recipe,\n",


### PR DESCRIPTION
The response_schema and the output indicates that only one recipe should be returned, but the prompt requested three.