### PR TITLE
Add license header checking app

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -1,0 +1,13 @@
+# Lint check for license headers.
+# See: https://github.com/googleapis/repo-automation-bots/tree/main/packages/header-checker-lint
+allowedCopyrightHolders:
+  - 'Google LLC'
+allowedLicenses:
+  - 'Apache-2.0'
+sourceFileExtensions:
+  - 'py'
+  - 'sh'
+  - 'ts'
+  - 'js'
+  - 'java'
+  # Note that separate nblint checks will handle *.ipynb files.

--- a/quickstarts/file-api/sample.js
+++ b/quickstarts/file-api/sample.js
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 const dotenv = require('dotenv');
 const fs = require('fs');
 const {google} = require('googleapis');

--- a/quickstarts/file-api/sample.py
+++ b/quickstarts/file-api/sample.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import google.generativeai as genai
 import os
 from dotenv import load_dotenv

--- a/quickstarts/file-api/sample.sh
+++ b/quickstarts/file-api/sample.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
+# Copyright 2025 Google LLC
 #
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Upload a file using the GenAI File API via curl.
 api_key=""
 input_file=""


### PR DESCRIPTION
Almost the same config as the generative-ai-docs repo: https://github.com/google/generative-ai-docs/blob/main/.github/header-checker-lint.yml