### PR TITLE
Fix: Broken Vertex AI links in Gemini Notebooks

### DIFF
--- a/gemini-2/search_tool_for_research_report.ipynb
+++ b/gemini-2/search_tool_for_research_report.ipynb
@@ -156,7 +156,7 @@
       "source": [
         "### Initialize SDK client\n",
         "\n",
-        "With the new SDK you now only need to initialize a client with you API key (or OAuth if using [Vertex AI](https://link_to_vertex_AI)). The model is now set in each call."
+        "With the new SDK you now only need to initialize a client with you API key (or OAuth if using [Vertex AI](https://cloud.google.com/vertex-ai)). The model is now set in each call."
       ]
     },
     {

--- a/gemini-2/thinking.ipynb
+++ b/gemini-2/thinking.ipynb
@@ -144,7 +144,7 @@
       "source": [
         "### Initialize SDK client\n",
         "\n",
-        "With the new SDK you now only need to initialize a client with you API key (or OAuth if using [Vertex AI](https://link_to_vertex_AI)). The model is now set in each call.\n",
+        "With the new SDK you now only need to initialize a client with you API key (or OAuth if using [Vertex AI](https://cloud.google.com/vertex-ai)). The model is now set in each call.\n",
         "\n",
         "You are going to use a flag named `thoughts` to differentiate between the thoughts and the answer, and since the model is experimental, the flag is only available with the `v1alpha` version of the API. Everything else should work fine with the usual APIs."
       ]

--- a/gemini-2/video_understanding.ipynb
+++ b/gemini-2/video_understanding.ipynb
@@ -180,7 +180,7 @@
       "source": [
         "### Initialize SDK client\n",
         "\n",
-        "With the new SDK you now only need to initialize a client with you API key (or OAuth if using [Vertex AI](https://link_to_vertex_AI)). The model is now set in each call."
+        "With the new SDK you now only need to initialize a client with you API key (or OAuth if using [Vertex AI](https://cloud.google.com/vertex-ai)). The model is now set in each call."
       ]
     },
     {


### PR DESCRIPTION
Updated the Vertex AI documentation link from a placeholder (https://link_to_vertex_AI) to the correct Google Cloud documentation URL (https://cloud.google.com/vertex-ai) in the following notebooks:
- gemini-2/search_tool_for_research_report.ipynb
- gemini-2/thinking.ipynb
- gemini-2/video_understanding.ipynb