### PR TITLE
Fix: Broken links in jupyter notebooks

### DIFF
--- a/examples/Guess_the_shape.ipynb
+++ b/examples/Guess_the_shape.ipynb
@@ -229,7 +229,7 @@
       "source": [
         "## Further reading\n",
         "\n",
-        "In this notebook, you included images directly in the prompt. This is fine for small images. If your prompts will exceed 20MB in size, you can use the [Files API](https://github.com/google-gemini/cookbook/tree/main/preview/file-api) to upload your images (and other media types) in advance."
+        "In this notebook, you included images directly in the prompt. This is fine for small images. If your prompts will exceed 20MB in size, you can use the [Files API](https://github.com/google-gemini/cookbook/tree/main/quickstarts/file-api) to upload your images (and other media types) in advance."
       ]
     }
   ],

--- a/examples/langchain/Gemini_LangChain_QA_Chroma_WebLoad.ipynb
+++ b/examples/langchain/Gemini_LangChain_QA_Chroma_WebLoad.ipynb
@@ -486,7 +486,7 @@
       "source": [
         "### Create prompt templates\n",
         "\n",
-        "You'll use LangChain's [PromptTemplate](https://python.langchain.com/docs/modules/model_io/prompts/prompt_templates/) to generate prompts to the LLM for answering questions.\n",
+        "You'll use LangChain's [PromptTemplate](https://python.langchain.com/docs/how_to/#prompt-templates) to generate prompts to the LLM for answering questions.\n",
         "\n",
         "In the `llm_prompt`, the variable `question` will be replaced later by the input question, and the variable `context` will be replaced by the relevant text from the website retrieved from the Chroma vector store."
       ]

--- a/examples/langchain/Gemini_LangChain_QA_Pinecone_WebLoad.ipynb
+++ b/examples/langchain/Gemini_LangChain_QA_Pinecone_WebLoad.ipynb
@@ -479,7 +479,7 @@
       "source": [
         "### Create prompt templates\n",
         "\n",
-        "You'll use LangChain's [PromptTemplate](https://python.langchain.com/docs/modules/model_io/prompts/prompt_templates/) to generate prompts to the LLM for answering questions.\n",
+        "You'll use LangChain's [PromptTemplate](https://python.langchain.com/docs/how_to/#prompt-templates) to generate prompts to the LLM for answering questions.\n",
         "\n",
         "In the `llm_prompt`, the variable `question` will be replaced later by the input question, and the variable `context` will be replaced by the relevant text from the website retrieved from the Pinecone vector store."
       ]

--- a/examples/langchain/Gemini_LangChain_Summarization_WebLoad.ipynb
+++ b/examples/langchain/Gemini_LangChain_Summarization_WebLoad.ipynb
@@ -258,7 +258,7 @@
       "source": [
         "### Create prompt templates\n",
         "\n",
-        "You'll use LangChain's [`PromptTemplate`](https://python.langchain.com/docs/modules/model_io/prompts/prompt_templates/) to generate prompts for summarizing the text.\n",
+        "You'll use LangChain's [`PromptTemplate`](https://python.langchain.com/docs/how_to/#prompt-templates) to generate prompts for summarizing the text.\n",
         "\n",
         "To summarize the text from the website, you will need the following prompts.\n",
         "1. Prompt to extract the data from the output of `WebBaseLoader`, named `doc_prompt`\n",


### PR DESCRIPTION
Updated internal links in LangChain examples to point to the correct documentation sections and also updated the correct GitHub URL for Files API in `examples` notebooks.