### PR TITLE
docs: Add comment about response modalities limitation

### DIFF
--- a/gemini-2/live_api_starter.py
+++ b/gemini-2/live_api_starter.py
@@ -79,7 +79,7 @@ DEFAULT_MODE = "camera"
 
 client = genai.Client(http_options={"api_version": "v1alpha"})
 
-CONFIG = {"generation_config": {"response_modalities": ["AUDIO"]}}
+CONFIG = {"generation_config": {"response_modalities": ["AUDIO"]}} # While Gemini 2.0 Flash is in experimental preview mode, only one of AUDIO or TEXT may be passed here.
 
 pya = pyaudio.PyAudio()
 

--- a/gemini-2/live_api_starter.py
+++ b/gemini-2/live_api_starter.py
@@ -79,7 +79,9 @@ DEFAULT_MODE = "camera"
 
 client = genai.Client(http_options={"api_version": "v1alpha"})
 
-CONFIG = {"generation_config": {"response_modalities": ["AUDIO"]}} # While Gemini 2.0 Flash is in experimental preview mode, only one of AUDIO or TEXT may be passed here.
+# While Gemini 2.0 Flash is in experimental preview mode, only one of AUDIO or
+# TEXT may be passed here.
+CONFIG = {"generation_config": {"response_modalities": ["AUDIO"]}}
 
 pya = pyaudio.PyAudio()
 


### PR DESCRIPTION
This PR adds a comment to clarify that only one response modality (`AUDIO` or `TEXT`) can be used in the `live_api_starter.py` file 

Addresses feedback from issue #386.