### PR TITLE
Update Get_started_thinking.ipynb

### DIFF
--- a/quickstarts/Get_started_thinking.ipynb
+++ b/quickstarts/Get_started_thinking.ipynb
@@ -455,7 +455,6 @@
       "source": [
         "response = client.models.generate_content(\n",
         "    model=\"gemini-2.0-flash-exp\",\n",
-        "    config={'thinking_config': {'include_thoughts': True}},\n",
         "    contents='How can I simplify this? `(Math.round(radius/pixelsPerMile * 10) / 10).toFixed(1);`. Be concise.'\n",
         ")\n",
         "\n",


### PR DESCRIPTION
Removed  "`config={'thinking_config': {'include_thoughts': True}},\n`", from the code script because it gives 400 error as `include_thoughts` is not supported with "gemini-2.0-flash-exp".