### PR TITLE
Correct broken link to Get_started.md in quickstarts/README.md

### DIFF
--- a/quickstarts/README.md
+++ b/quickstarts/README.md
@@ -9,7 +9,7 @@ When you'll be confident is your Gemini capabilities, the [examples](../examples
 
 If you are new to Gemini API, you should start with those two guides:
 * [Authentication](./Authentication.ipynb): Start here to learn how you can set up your API key so you can get access to the Gemini API.
-* [Get Started](./Get_Started.ipynb): Learn how to make your first calls to the Gemini API and get a quick overview of everything it can do.
+* [Get Started](./Get_started.ipynb): Learn how to make your first calls to the Gemini API and get a quick overview of everything it can do.
 <br/><br/>
 
 Then learn about how to **get started** with the other models that you can use with the API:


### PR DESCRIPTION
## Description

The link to "./Get_started.md" is "./Get_Started.md", which leads to a 404.

## Changes
- update link to point to the right filename