### PR TITLE
Fixed ValidationError in Get_started_LiveAPI - Simple text to audio  fixes #529

### DIFF
--- a/quickstarts/Get_started_LiveAPI.ipynb
+++ b/quickstarts/Get_started_LiveAPI.ipynb
@@ -359,8 +359,7 @@
         }
       ],
       "source": [
-        "config={\n",
-        "    \"generation_config\": {\"response_modalities\": [\"AUDIO\"]}}\n",
+        "config= {\"response_modalities\": [\"AUDIO\"]}\n",
         "\n",
         "\n",
         "\n",


### PR DESCRIPTION
updating the `config`
from
```bash
config={
    "generation_config": {"response_modalities": ["AUDIO"]}}
```
to
```bash
config= {"response_modalities": ["AUDIO"]}
```
fixes the issue.
Inspiration : the `config` structure in the `Send and receive a text message` cell from [here](https://ai.google.dev/gemini-api/docs/multimodal-live#text-to-text-example) was followed.

