### PR TITLE
Set up a TS folder and add an explicitly typed chat example 

### DIFF
--- a/examples/typescript/.gitignore
+++ b/examples/typescript/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -1,0 +1,29 @@
+# Gemini examples for TypeScript
+
+This folder contains a collection of examples for the Gemini API, with TypeScript. These are advanced examples and might be quite complex as they often use one of more Gemini capabilities.
+
+To try out these samples, you'll need Node.js v18+ and `tsx`.
+
+## Setup
+Install the dependencies by running the following command:
+
+```
+npm install
+```
+
+## Requirements
+
+Follow the instructions on Google AI Studio [setup page](https://makersuite.google.com/app/apikey) to obtain an API key. This sample assumes that you're providing an `API_KEY` environment variable.
+
+Input your API key into the `API_KEY` environment variable and run the following command in your command line:
+
+```
+export API_KEY=<your-api-key>
+```
+## Table of contents
+
+Each of these sample files can be run using Node.js and `tsx` from the command line.  You can run the file by typing `npx tsx <file-name>.ts`.
+
+| File                                                     | Description | Features | Open |
+|----------------------------------------------------------| ----------- | -------- | ---- |
+| [castle_detection_with_explicit_types.ts](./castle_detection_with_explicit_types.ts)    | Ask Gemini to describe a medieval castle | Explicitly typed chat, Image detection | `npx tsx castle_detection_with_explicit_types.ts` |

--- a/examples/typescript/castle_detection_with_explicit_types.ts
+++ b/examples/typescript/castle_detection_with_explicit_types.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { 
+    ChatSession, 
+    Content, 
+    GenerateContentStreamResult, 
+    GenerativeContentBlob, 
+    GenerativeModel, 
+    GoogleGenerativeAI,
+    GoogleGenerativeAIError
+} from "@google/generative-ai";
+import fs from "fs";
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const mediaPath = __dirname + "/../assets";
+
+if (!process.env.API_KEY) {
+  throw new Error('API_KEY environment variable is required. You can get one from https://makersuite.google.com/app/apikey');
+}
+
+/**
+ * This example demonstrates how to use the Gemini API for a medieval castle analysis chat tool
+ * It shows how to:
+ * 1. Set up a chat session with explicit TypeScript types
+ * 2. Include conversation history and system instruction
+ * 3. Send images for analysis
+ * 4. Handle streaming responses
+ */
+async function chatWithExplicitTypes(): Promise<void> {
+  // Make sure to import the Google Generative AI Node.js SDK
+  // import { GoogleGenerativeAI } from "@google/generative-ai";
+  // Initialize the Gemini API with your API key.
+  const genAI: GoogleGenerativeAI = new GoogleGenerativeAI(process.env.API_KEY);
+  
+  // Create a specialized castle expert model using the system instruction.
+  const model: GenerativeModel = genAI.getGenerativeModel({ 
+    model: "gemini-1.5-flash",
+    systemInstruction: "You are a medieval castle expert."
+  });
+
+  /* 
+  * Set up the initial conversation with the castle expert. 
+  * If you leave out the history, the model will start with a blank slate. 
+  */
+  const history: Content[] = [
+    {
+      role: "user",
+      parts: [{ text: "Hello. Would you like to see my medieval castle?" }],
+    },
+    {
+      role: "model",
+      parts: [{ text: "Yes, I would love to see your medieval castle! Please tell me about it or describe it to me." }],
+    },
+  ];
+
+  // Start a new chat session with our conversation history
+  const chat: ChatSession = model.startChat({ history });
+
+  // Prepare the castle image for analysis
+  const image: GenerativeContentBlob = {
+    data: Buffer.from(fs.readFileSync(`${mediaPath}/castle.png`)).toString("base64"),
+    mimeType: "image/png"
+  };
+
+  // Send the image to the model and stream its analysis
+  // For a non-streaming response, use sendMessage instead of sendMessageStream
+  try {
+    const resultStream: GenerateContentStreamResult = await chat.sendMessageStream([
+      "Here it is! My medieval castle.", 
+      { inlineData: image }
+    ]);
+
+    // Print the streaming response
+    process.stdout.write('\n\nModel response:\n');
+    for await (const chunk of resultStream.stream) {
+        const chunkText = chunk.text();
+        process.stdout.write(chunkText);
+    }
+  } catch (error) {
+    if (error instanceof GoogleGenerativeAIError) {
+        console.error('A Gemini-specific error occurred: ', error.message);
+    } else {
+        console.error('An error occurred: ', error);
+    }
+  }
+}
+
+chatWithExplicitTypes().catch(error => {
+    console.error('Error running examples: ', error);
+    process.exit(1);
+});

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -1,0 +1,21 @@
+{
+    "name": "gemini-ts-examples",
+    "version": "1.0.0",
+    "description": "Usage examples for the Gemini Node.js/TypeScript SDK.",
+    "scripts": {
+      "build": "tsc",
+      "start": "ts-node"
+    },
+    "dependencies": {
+      "@google/generative-ai": "^0.24.0"
+    },
+    "devDependencies": {
+      "@types/node": "^20.0.0",
+      "tsx": "^4.19.3",
+      "typescript": "^5.3.0"
+    },
+    "license": "Apache-2.0",
+    "engines": {
+      "node": ">=18.0.0"
+    }
+  }

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+      "noImplicitAny": true,
+      "module": "es2020",
+      "target": "es2020",
+      "allowJs": true,
+      "moduleResolution": "node",
+      "declaration": true,
+      "outDir": "dist",
+      "allowSyntheticDefaultImports": true
+    }
+  }


### PR DESCRIPTION
OK -- I've been working on this for a few days now. I hope this will be the first example in what will be a growing collection of TS implementations!

This PR sets up a dedicated TS example folder, scaffolding it with a basic `package.json`, `README.md`, and `tsconfig.json` structure so that future TS contributions can just go in here. It also includes one initial example of a medieval castle analysis chat tool that explicitly exposes the SDK types (future TS examples probably don't need to be this explicit) and makes use of Gemini's image detection capability. I'm using the available castle.png sitting in the assets folder, but of course can always change this to something more exciting.

The TS folder is currently located inside the `examples` folder. I'm open to suggestions if you think this should be moved somewhere else @Giom-V  and @markmcd. Also, any feedback on structure, writing, or best practices would be much appreciated.

Edit: I'll go through the example and rewrite it slightly to better adhere to https://developers.google.com/style. Marking this as a draft for now.