### PR TITLE
Moving the images to a bucket to save on notebook size

### DIFF
--- a/quickstarts/Image_out.ipynb
+++ b/quickstarts/Image_out.ipynb
@@ -400,7 +400,7 @@
         "id": "wnwSzvCTltWd"
       },
       "source": [
-        "The output of the previous code cell could not be saved in the notbook without making it too big to be managed by Github, but here's what it should look like when you run it:\n",
+        "The output of the previous code cell could not be saved in the notebook without making it too big to be managed by Github, but here's what it should look like when you run it:\n",
         "\n",
         "----------\n",
         "\n",


### PR DESCRIPTION
Fixing #551 by moving the images to a bucket to save on notebook size so Github can open it.