### PR TITLE
Update Function_calling.ipynb quickstart

### DIFF
--- a/quickstarts/Function_calling.ipynb
+++ b/quickstarts/Function_calling.ipynb
@@ -1134,7 +1134,9 @@
         "      brightness: The brightness of the lights, 0.0 is off, 1.0 is full.\n",
         "    \"\"\"\n",
         "    print(f\"Lights are now set to {brightness:.0%}\")\n",
-        "    return True"
+        "    return True\n",
+        "\n",
+        "house_fns = [power_disco_ball, start_music, dim_lights]"
       ]
     },
     {


### PR DESCRIPTION
This PR adds the `house_fns` list definition to `quickstarts/Function_calling.ipynb`. This list contains the functions (`power_disco_ball`, `start_music`, `dim_lights`) used in the "Parallel function calls" example section, which was missing its definition.