### PR TITLE
Exclude rebase/merge files from lint/fmt checks

### DIFF
--- a/.github/workflows/notebooks.yaml
+++ b/.github/workflows/notebooks.yaml
@@ -16,7 +16,9 @@ jobs:
     name: Notebook format
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Get *full* history
     - uses: actions/setup-python@v4
     - name: Install tensorflow-docs
       run: python3 -m pip install -U git+https://github.com/tensorflow/docs
@@ -26,7 +28,8 @@ jobs:
       run: |
         if [ "${{ github.event_name }}" == "pull_request" ]; then
           # Only check notebooks modified in this pull request
-          readarray -t changed_notebooks < <(git diff --name-only main | grep '\.ipynb$' || true)
+          base_commit=$(git merge-base HEAD ${{ github.event.pull_request.base.sha }})
+          readarray -t changed_notebooks < <(git diff --name-only "${base_commit}...HEAD" "*.ipynb")
         else
           # Manual run, check everything
           readarray -t changed_notebooks < <(find -name '*.ipynb')
@@ -55,7 +58,8 @@ jobs:
       run: |
         if [ "${{ github.event_name }}" == "pull_request" ]; then
           # Only check notebooks modified in this pull request
-          readarray -t changed_notebooks < <(git diff --name-only main | grep '\.ipynb$' | grep -v 'gemini-2/' || true)
+          base_commit=$(git merge-base HEAD ${{ github.event.pull_request.base.sha }})
+          readarray -t changed_notebooks < <(git diff --name-only "${base_commit}...HEAD" "*.ipynb" | grep -v 'gemini-2/' || true)
         else
           # Manual run, check everything
           readarray -t changed_notebooks < <(find . -name '*.ipynb' | grep -v 'gemini-2/')

--- a/.github/workflows/notebooks.yaml
+++ b/.github/workflows/notebooks.yaml
@@ -46,7 +46,9 @@ jobs:
     name: Notebook lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Get *full* history
     - uses: actions/setup-python@v4
     - name: Install tensorflow-docs
       run: python3 -m pip install -U git+https://github.com/tensorflow/docs


### PR DESCRIPTION
Currently we use `git diff main` to find files changed in this PR, but that includes modifications due to rebasing.

This change uses the PR's merge base commit as the diff point to ensure the same files that appear in the "Files" list are the ones that get linted/fmt'd

Also I realised we don't need to use `|grep *.ipynb`, for simple file paths we can just pass "*.ipynb" to `git diff`.