### PR TITLE
Text update: remove reference and link to unavailable content

### DIFF
--- a/quickstarts/Video_understanding.ipynb
+++ b/quickstarts/Video_understanding.ipynb
@@ -595,7 +595,7 @@
       "source": [
         "# Next Steps\n",
         "\n",
-        "Try with you own videos using the [AI Studio's live demo](https://aistudio.google.com/starter-apps/video) or play with the examples from this notebook (in case you haven't seen, there are other prompts you can try in the dropdowns).\n",
+        "Play with the examples from this notebook (in case you haven't seen, there are other prompts you can try in the dropdowns).\n",
         "\n",
         "For more examples of the Gemini capabilities, check the other guide from the [Cookbook](https://github.com/google-gemini/cookbook/). You'll learn how to use the [Live API](../quickstarts/Get_started_LiveAPI.ipynb), juggle with [multiple tools](../quickstarts/Get_started_LiveAPI_tools.ipynb) or use Gemini 2.0 [spatial understanding](../quickstarts/Spatial_understanding.ipynb) abilities.\n",
         "\n",


### PR DESCRIPTION
Remove reference and link to AI Studio's live demo as it is no longer available.