### PR TITLE
feat: Auto formatting workflow with nbfmt

### DIFF
--- a/.github/workflows/notebooks.yaml
+++ b/.github/workflows/notebooks.yaml
@@ -1,46 +1,83 @@
 # Notebook-related checks
-
 name: Notebooks
 
 on:
-  # Relevant PRs
   pull_request:
     paths:
-    - "**.ipynb"
-  # Allow manual runs
+      - "**.ipynb"
   workflow_dispatch:
 
 jobs:
-  # Format all notebooks.
   nbfmt:
-    name: Notebook format
+    name: Notebook format and testing
     runs-on: ubuntu-latest
+
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0  # Get *full* history
-    - uses: actions/setup-python@v4
-    - name: Install tensorflow-docs
-      run: python3 -m pip install -U git+https://github.com/tensorflow/docs
-    - name: Fetch main branch
-      run: git fetch -u origin main:main
-    - name: Check notebook formatting
-      run: |
-        if [ "${{ github.event_name }}" == "pull_request" ]; then
-          # Only check notebooks modified in this pull request
-          base_commit=$(git merge-base HEAD ${{ github.event.pull_request.base.sha }})
-          readarray -t changed_notebooks < <(git diff --name-only "${base_commit}...HEAD" "*.ipynb")
-        else
-          # Manual run, check everything
-          readarray -t changed_notebooks < <(find -name '*.ipynb')
-        fi
-        if [[ ${#changed_notebooks[@]} == 0 ]]; then
-          echo "No notebooks modified in this pull request."
-          exit 0
-        else
-          echo "Check formatting with nbfmt:"
-          python3 -m tensorflow_docs.tools.nbfmt --test "${changed_notebooks[@]}"
-        fi
+      - uses: actions/checkout@v4
+        with:
+          ref:   ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.BOT_PAT }}      # PAT for auto-running workflow after formating commit
+          fetch-depth: 0                     # merge-base needs full history
+
+      - uses: actions/setup-python@v4
+
+      - name: Install tensorflow-docs
+        run: python -m pip install -qU git+https://github.com/tensorflow/docs
+
+      - name: Configure Git user
+        run: |
+          git config --local user.email "servicebot@github.com"
+          git config --local user.name  "service"
+
+      # Main loop: test each notebook, format if needed, single commit at the end
+      - name: Check notebooks one-by-one, format if required
+        run: |
+          set -e
+
+          # Collect notebooks touched in this PR
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base=$(git merge-base HEAD origin/${{ github.event.pull_request.base.ref }})
+            readarray -t notebooks < <(git diff --name-only "${base}...HEAD" "*.ipynb")
+          else
+            readarray -t notebooks < <(find . -name '*.ipynb')
+          fi
+
+          if [[ ${#notebooks[@]} -eq 0 ]]; then
+            echo "No notebooks modified in this pull request."
+            exit 0
+          fi
+
+          echo "Notebook list: ${notebooks[*]}"
+
+          # Loop: run --test, format when necessary
+          reformatted=false
+          for nb in "${notebooks[@]}"; do
+            echo "::group::${nb}"
+            set +e
+            python -m tensorflow_docs.tools.nbfmt --test "${nb}"
+            test_rc=$?
+            set -e
+
+            if [[ $test_rc -eq 0 ]]; then
+              echo "${nb} already formatted"
+            else
+              echo "${nb} needs formatting → applying formatter"
+              python -m tensorflow_docs.tools.nbfmt "${nb}"
+              reformatted=true
+            fi
+            echo "::endgroup::"
+          done
+
+          # One commit if anything changed
+          if [[ "$reformatted" == "true" ]]; then
+            git add "${notebooks[@]}"
+            git commit -m "style: auto-format notebooks with nbfmt"
+            git push
+          else
+            echo "All notebooks already in canonical format – nothing to commit."
+          fi
 
   nblint:
     name: Notebook lint


### PR DESCRIPTION
This PR introduces a GitHub Actions job that
- checks every notebook touched in a PR,
- formats any notebook that fails the check,
- pushes a single “style: auto-format notebooks with nbfmt” commit, and
- re-runs the full CI suite on the now-tidy notebooks.

The result is cleaner diffs and less manual friction for contributors.

### Changes:
.github/workflows/notebook.yaml
‑ new nbfmt job that loops over changed notebooks, runs nbfmt --test, formats and commits when necessary.
‑ uses a personal-access token (PAT) stored in the secret BOT_PAT so the bot’s commit retriggers all workflows.

### Setup:
Have a service account as a collaborator, so formatting commits made by it auto-run the rest of workflow.
Generate a classic PAT with scopes:
`repo` (push rights to push the formatting commit) and `workflow` (let the push trigger Actions).

In the cookbook repo, add this PAT as a repo secret, so it's safe from forks as well:
Name: BOT_PAT
Value: <paste-the-token>

### Security notes
Secrets added at the repository level are not passed to workflows triggered from forked PRs; outside contributors therefore cannot access the PAT.
- The workflow is pinned to first-party actions or SHA-pinned where applicable.
- The PAT is used only inside the formatter job to perform the push.

