### PR TITLE
Use known/tested models for browser demos

### DIFF
--- a/examples/Browser_as_a_tool.ipynb
+++ b/examples/Browser_as_a_tool.ipynb
@@ -153,7 +153,7 @@
         "client = genai.Client(api_key=GOOGLE_API_KEY)\n",
         "\n",
         "LIVE_MODEL = 'gemini-2.0-flash-live-001'  # @param ['gemini-2.0-flash-live-001', 'gemini-live-2.5-flash-preview', 'gemini-2.5-flash-preview-native-audio-dialog', 'gemini-2.5-flash-exp-native-audio-thinking-dialog'] {allow-input: true, isTemplate: true}\n",
-	"MODEL = 'gemini-2.5-flash'  # @param ['gemini-2.5-flash'] {allow-input: true, isTemplate: true}"
+        "MODEL = 'gemini-2.5-flash'  # @param ['gemini-2.5-flash'] {allow-input: true, isTemplate: true}"
       ]
     },
     {


### PR DESCRIPTION
These are known to be stable, so using as defaults for I/O workshops.