### PR TITLE
updated model to gemini-live-2.5-flash-preview in `Get_started_liveAPI_tools.ipynb`

### DIFF
--- a/quickstarts/Get_started_LiveAPI_tools.ipynb
+++ b/quickstarts/Get_started_LiveAPI_tools.ipynb
@@ -2031,18 +2031,6 @@
     "kernelspec": {
       "display_name": "Python 3",
       "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.13.3"
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
- Updated live api model
-  Rerun the notebook
- Replaced all instances of  **gemini 2.0**   to **gemini 2.5**