### PR TITLE
Return Markdown in the web browser example

### DIFF
--- a/examples/Browser_as_a_tool.ipynb
+++ b/examples/Browser_as_a_tool.ipynb
@@ -590,7 +590,7 @@
         "      driver.save_screenshot(SCREENSHOT_FILE)\n",
         "\n",
         "      print(f\"Screenshot saved to {SCREENSHOT_FILE}\")\n",
-        "      return \"ok\"\n",
+        "      return markdownify.markdownify(driver.page_source)\n",
         "\n",
         "    except Exception as e:\n",
         "      print(f\"An error occurred: {e}\")\n",
@@ -603,7 +603,7 @@
         "\n",
         "\n",
         "url = \"https://en.wikipedia.org/wiki/Castle\"\n",
-        "browse_url(url)"
+        "browse_url(url);"
       ]
     },
     {


### PR DESCRIPTION
Currently the visual tool returns an image but if we return markdown too, it can also browse links on the page, and grab any text that is off-screen.