### PR TITLE
docs: fix typo 'speciefying' in qdrant guide

### DIFF
--- a/examples/qdrant/Qdrant_similarity_search.ipynb
+++ b/examples/qdrant/Qdrant_similarity_search.ipynb
@@ -297,7 +297,7 @@
         "\n",
         "To use the embedding model, you have to use the `embed_content` function from the `google-genai` package. To learn more about the embedding model, read the [model documentation](https://ai.google.dev/gemini-api/docs/embeddings).\n",
         "\n",
-        "One of the arguments passed to the embedding function is `task_type`. Speciefying the `task_type` parameter ensures the model produces appropriate embeddingsfor the expected task and inputs. It is a string that can take on one of the following values:\n",
+        "One of the arguments passed to the embedding function is `task_type`. Specifying the `task_type` parameter ensures the model produces appropriate embeddingsfor the expected task and inputs. It is a string that can take on one of the following values:\n",
         "\n",
         "| task_type\t  |  Description |\n",
         "|---|---|\n",


### PR DESCRIPTION
Corrected "speciefying" to "specifying".