### PR TITLE
Spelling: "fixced" to "fixed", Context Caching

### DIFF
--- a/quickstarts/Get_started.ipynb
+++ b/quickstarts/Get_started.ipynb
@@ -138,7 +138,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": null,
       "metadata": {
         "id": "HghvVpbU0Uap"
       },
@@ -189,7 +189,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "T8md0ayAJ-RZ"
+        "id": "T8md0ayAJ-RZ",
+        "outputId": "6fe67b49-897a-4f4e-c9d4-31aa9bdaeed6"
       },
       "outputs": [
         {
@@ -232,7 +233,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "Z7WFm928wEYR"
+        "id": "Z7WFm928wEYR",
+        "outputId": "1b96b8b4-1be4-4d76-c7be-e48dd4a59049"
       },
       "outputs": [
         {
@@ -269,7 +271,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "bQ3zu5udSBuD"
+        "id": "bQ3zu5udSBuD",
+        "outputId": "e76bf74d-5f4b-46d6-9ca6-f63e5bf6436d"
       },
       "outputs": [
         {
@@ -309,7 +312,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "cDxd7Pp_SELb"
+        "id": "cDxd7Pp_SELb",
+        "outputId": "387327a1-2551-4f93-8c17-30c090681d31"
       },
       "outputs": [
         {
@@ -380,7 +384,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "r5izy6jsbEnL"
+        "id": "r5izy6jsbEnL",
+        "outputId": "b5466b6a-2520-4159-c74c-eac86841451f"
       },
       "outputs": [
         {
@@ -459,7 +464,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "SJIvAfMqbzQL"
+        "id": "SJIvAfMqbzQL",
+        "outputId": "66fb036c-5cba-469c-c318-cc011c8ea5e9"
       },
       "outputs": [
         {
@@ -551,7 +557,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "SnzMJJ-adOfX"
+        "id": "SnzMJJ-adOfX",
+        "outputId": "6397a00c-fe3e-4cac-cec2-d72007ae04b7"
       },
       "outputs": [
         {
@@ -747,7 +754,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "9qAObeZMdgln"
+        "id": "9qAObeZMdgln",
+        "outputId": "98924516-7f6b-4e04-f88d-11011a36ef2d"
       },
       "outputs": [
         {
@@ -1116,7 +1124,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "hq1bAsX8ZRS3"
+        "id": "hq1bAsX8ZRS3",
+        "outputId": "cf325073-1fd1-4975-955d-1f9063c87b91"
       },
       "outputs": [
         {
@@ -1168,7 +1177,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "xRJHVjr-gqHi"
+        "id": "xRJHVjr-gqHi",
+        "outputId": "4a404c8f-9324-4678-e259-a020d9497f10"
       },
       "outputs": [
         {
@@ -1229,7 +1239,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "qbdnNzGL6R_2"
+        "id": "qbdnNzGL6R_2",
+        "outputId": "be1328a8-d2f7-4fed-f70b-cff1e6b3f10d"
       },
       "outputs": [
         {
@@ -1309,7 +1320,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "3gIsSNqXtOXB"
+        "id": "3gIsSNqXtOXB",
+        "outputId": "4ab3ab34-020c-4c79-a03d-77212684d6f6"
       },
       "outputs": [
         {
@@ -1375,7 +1387,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "OPTI7noYuwgr"
+        "id": "OPTI7noYuwgr",
+        "outputId": "5fda306e-ab5f-4b36-c9ba-37d2f9c16605"
       },
       "outputs": [
         {
@@ -1488,7 +1501,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "APk6sXO6wLQp"
+        "id": "APk6sXO6wLQp",
+        "outputId": "65d6bf2a-eea9-4b64-ac5d-eec90e041097"
       },
       "outputs": [
         {
@@ -1548,7 +1562,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "fY062-nsGLBu"
+        "id": "fY062-nsGLBu",
+        "outputId": "b48feccc-b001-48c5-dbfb-76092299e561"
       },
       "outputs": [
         {
@@ -1679,7 +1694,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "8FVVJHb828le"
+        "id": "8FVVJHb828le",
+        "outputId": "700f5eb4-2956-402e-b171-d1006e3a1466"
       },
       "outputs": [
         {
@@ -1706,7 +1722,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "NlJ9NwRGT6d1"
+        "id": "NlJ9NwRGT6d1",
+        "outputId": "a8734924-e597-43a7-f45e-aa00dec03da4"
       },
       "outputs": [
         {
@@ -1765,7 +1782,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "3Sa6lEH9Tjm5"
+        "id": "3Sa6lEH9Tjm5",
+        "outputId": "187ba480-b216-43a4-e5bc-b44cdd8d7fd6"
       },
       "outputs": [
         {
@@ -1792,7 +1810,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "kC3bJQJcUKFk"
+        "id": "kC3bJQJcUKFk",
+        "outputId": "ac607ff7-28e6-406c-e41c-1e66e477b867"
       },
       "outputs": [
         {
@@ -1915,7 +1934,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "b0BfhLDFWfCS"
+        "id": "b0BfhLDFWfCS",
+        "outputId": "2d342f44-273d-4b79-dd3b-b719c53519c8"
       },
       "outputs": [
         {
@@ -1951,7 +1971,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "tH2h2WDVWptt"
+        "id": "tH2h2WDVWptt",
+        "outputId": "a0be2a1b-639c-450e-e37d-a9fd4a48424a"
       },
       "outputs": [
         {
@@ -2014,7 +2035,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "lCSuGd9i9fEB"
+        "id": "lCSuGd9i9fEB",
+        "outputId": "1910ab57-a8a9-47dd-f1b9-f03c4e094352"
       },
       "outputs": [
         {
@@ -2041,7 +2063,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "0wjKO0eI9yps"
+        "id": "0wjKO0eI9yps",
+        "outputId": "48e5ddfa-6ec4-4a4d-b06b-e680444d5081"
       },
       "outputs": [
         {
@@ -2096,7 +2119,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "e9ohtLxU-SFE"
+        "id": "e9ohtLxU-SFE",
+        "outputId": "3f3bde78-4357-4b5a-c0d2-4bd669e2d5e5"
       },
       "outputs": [
         {
@@ -2135,7 +2159,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "PY1WlxMk-0Uy"
+        "id": "PY1WlxMk-0Uy",
+        "outputId": "ecc037ad-d099-4a65-bead-53b8c7a477bf"
       },
       "outputs": [
         {
@@ -2165,7 +2190,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "eEk4P3fK_OcJ"
+        "id": "eEk4P3fK_OcJ",
+        "outputId": "ceca4579-8617-470d-bbc0-1e54ee6007ee"
       },
       "outputs": [
         {
@@ -2197,7 +2223,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "oMz9GIuvAiCO"
+        "id": "oMz9GIuvAiCO",
+        "outputId": "a841d055-e760-4ea8-c179-78bdb7bc3c56"
       },
       "outputs": [
         {
@@ -2216,7 +2243,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "cX82TyGL-e2O"
+        "id": "cX82TyGL-e2O",
+        "outputId": "3e431f9b-2eff-404d-9ad8-f989bd290df2"
       },
       "outputs": [
         {
@@ -2288,7 +2316,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "zcqXUrYSTrLQ"
+        "id": "zcqXUrYSTrLQ",
+        "outputId": "b906ee9c-52d5-4146-8aac-95e2690954fa"
       },
       "outputs": [
         {
@@ -2366,7 +2395,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "JgpP6_qTQeXR"
+        "id": "JgpP6_qTQeXR",
+        "outputId": "1322f374-9743-45a3-90d2-3d1053a73a64"
       },
       "outputs": [
         {
@@ -2450,7 +2480,7 @@
         "\n",
         "[Context caching](https://ai.google.dev/gemini-api/docs/caching?lang=python) lets you to store frequently used input tokens in a dedicated cache and reference them for subsequent requests, eliminating the need to repeatedly pass the same set of tokens to a model. You can find more caching examples [here](https://github.com/google-gemini/cookbook/blob/main/quickstarts/Caching.ipynb).\n",
         "\n",
-        "Note that for models older than 2.5, you needed to use fixced version models (often ending with `-001`)."
+        "Note that for models older than 2.5, you needed to use fixed version models (often ending with `-001`)."
       ]
     },
     {
@@ -2486,7 +2516,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "ZrZ64o5Sydm_"
+        "id": "ZrZ64o5Sydm_",
+        "outputId": "ee2b722a-4d01-42d4-fdc6-9ea336f0b9d9"
       },
       "outputs": [
         {
@@ -2529,7 +2560,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "7MBsaipow7m5"
+        "id": "7MBsaipow7m5",
+        "outputId": "9cd87bb7-eb8a-4eca-ccc5-3807980a695b"
       },
       "outputs": [
         {
@@ -2571,7 +2603,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "3be7c2339be3"
+        "id": "3be7c2339be3",
+        "outputId": "a97e8fa6-e7d3-480d-a743-5435c54bf32a"
       },
       "outputs": [
         {
@@ -2600,7 +2633,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "-Qo7-sU2w92j"
+        "id": "-Qo7-sU2w92j",
+        "outputId": "fe1c0cc3-5d1d-4602-a8c1-fcf5ca981434"
       },
       "outputs": [
         {
@@ -2673,9 +2707,10 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": null,
       "metadata": {
-        "id": "0afi69R9x_bh"
+        "id": "0afi69R9x_bh",
+        "outputId": "51fabe7a-bf33-46b4-b907-d3334ef0cd64"
       },
       "outputs": [
         {
@@ -2737,9 +2772,10 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
+      "execution_count": null,
       "metadata": {
-        "id": "zNeuBlNt4CRk"
+        "id": "zNeuBlNt4CRk",
+        "outputId": "992477ff-f89d-4a76-a30d-f598d017b00b"
       },
       "outputs": [
         {
@@ -2768,9 +2804,10 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": null,
       "metadata": {
-        "id": "s4oAtC8a4GYH"
+        "id": "s4oAtC8a4GYH",
+        "outputId": "7bd44005-94ea-45f3-a22f-b3af1130d038"
       },
       "outputs": [
         {
@@ -2812,7 +2849,8 @@
   "metadata": {
     "colab": {
       "name": "Get_started.ipynb",
-      "toc_visible": true
+      "toc_visible": true,
+      "provenance": []
     },
     "kernelspec": {
       "display_name": "Python 3",


### PR DESCRIPTION
Hello Google Developers, 

I noticed a marginal spelling error in the "Use Context Caching" section in the "Get_started.ipynb" from the Gemini cookbook quickstarts:

Commit Message = [Spelling: "fixced" to "fixed", Context Caching]

Full context:

_Note that for models older than 2.5, you needed to use fixced version models (often ending with `-001`)._

Please do let me know if there is anything else I can do, and if this is helpful. 

Thank you,

Aaron Howell