### PR TITLE
Deprecation status of SDK links

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ These fully functional, end-to-end applications showcase the power of Gemini in 
 
 The Gemini API is a REST API. You can call it directly using tools like `curl` (see [REST examples](https://github.com/google-gemini/cookbook/tree/main/quickstarts/rest/) or the great [Postman workspace](https://www.postman.com/ai-on-postman/google-gemini-apis/overview)), or use one of our official SDKs:
 * [Python](https://github.com/googleapis/python-genai)
-* [Go](https://github.com/google/generative-ai-go)
-* [Node.js](https://github.com/google/generative-ai-js)
+* [Go](https://github.com/googleapis/go-genai)
+* [Node.js](https://github.com/googleapis/js-genai)
 * [Dart (Flutter)](https://github.com/google/generative-ai-dart)
 * [Android](https://github.com/google/generative-ai-android)
 * [Swift](https://github.com/google/generative-ai-swift)

--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ The Gemini API is a REST API. You can call it directly using tools like `curl` (
 * [Node.js](https://github.com/googleapis/js-genai)
 * [Java](https://github.com/googleapis/java-genai)
 * [C#](https://github.com/googleapis/dotnet-genai/)
+* [Dart (Flutter)](https://github.com/google/generative-ai-dart) (deprecated)
+* [Android](https://github.com/google/generative-ai-android) (deprecated)
+* [Swift](https://github.com/google/generative-ai-swift) (deprecated)
 <br><br>
 
 ## Get Help


### PR DESCRIPTION
Go, Node.js, Dart, Android, and Swift SDKs were deprecated, but Go and Node.js have new repositories, so I changed their links. Dart, Android, and Swift SDKs don’t have new repositories yet, so I haven’t changed their URLs.