### PR TITLE
Added support for configuring retrieval count in file search

### DIFF
--- a/quickstarts/File_Search.ipynb
+++ b/quickstarts/File_Search.ipynb
@@ -360,7 +360,47 @@
         "        tools=[types.Tool(\n",
         "            file_search=types.FileSearch(\n",
         "                file_search_store_names=[file_search_store.name],\n",
-        "                top_k = N # N signifies the number of chunks to be retrieved \n",
+        "            )\n",
+        "        )]\n",
+        "    )\n",
+        ")\n",
+        "\n",
+        "print(response.text)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "oZP9ATopWhQ4"
+      },
+      "source": [
+        "#### Additional fields\n",
+        "\n",
+        "The `FileSearch` tool provides some options for configuring how the tool works, `top_k` and `metadata_filter`.\n",
+        "\n",
+        "`top_k` controls how many chunks will be returned from the search tool and passed to the generation step. This is the same example as before, but only 1 chunk will be used to generate the answer. This control can be helpful to guide the model if you know there is only one correct chunk to consider (`k=1`), or if you expect the chunks to have more overlap and you want to include more context (higher `top_k`).\n",
+        "\n",
+        "Metadata filtering is described in the next section, and you can find the full spec in the [API reference](https://ai.google.dev/api/caching#FileSearch)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "AX8avDUHYF2U"
+      },
+      "outputs": [],
+      "source": [
+        "top_K = 1 # @param {\"allow-input\":true, isTemplate: true}\n",
+        "\n",
+        "response = client.models.generate_content(\n",
+        "    model=MODEL_ID,\n",
+        "    contents='What does the text say about E.E. Cummings?',\n",
+        "    config=types.GenerateContentConfig(\n",
+        "        tools=[types.Tool(\n",
+        "            file_search=types.FileSearch(\n",
+        "                file_search_store_names=[file_search_store.name],\n",
+        "                top_k=top_K,\n",
         "            )\n",
         "        )]\n",
         "    )\n",


### PR DESCRIPTION
solves issue #1048 


@markmcd 
I added a parameter top_k that allows developers to increase this number of chunks  (e.g., to 20, 50, or more).
FileSearch already exposes a top_k parameter, and when I tested this locally, setting top_k did affect the number of retrieved chunks (e.g., with top_k=N, only N chunks were returned).

<img width="2426" height="796" alt="image" src="https://github.com/user-attachments/assets/7e813ad2-efcf-4423-8ed0-06eb3d76c711" />
<img width="1600" height="706" alt="image" src="https://github.com/user-attachments/assets/d86d286b-90eb-43af-8965-e5c141886325" />


Please let me know if this is fine or any other changes are needed.

Collaborated with @Ved015