### PR TITLE
Fix #906: Add websocket tool response examples and documentation

### DIFF
--- a/examples/WEBSOCKET_TOOL_RESPONSE_FIX.md
+++ b/examples/WEBSOCKET_TOOL_RESPONSE_FIX.md
@@ -265,7 +265,7 @@ async def test_tool_response():
 
 If you're still having issues:
 1. Check that your API key is valid
-2. Verify you're using the correct model (`gemini-2.0-flash-live-001`)
+2. Verify you're using a compatible model (e.g., `gemini-2.0-flash-live-001`)
 3. Ensure your websocket URI is correct
 4. Review the complete example in `Websocket_Tool_Call_Response_Example.py`
 5. Open an issue in the [cookbook repository](https://github.com/google-gemini/cookbook/issues)

--- a/examples/WEBSOCKET_TOOL_RESPONSE_FIX.md
+++ b/examples/WEBSOCKET_TOOL_RESPONSE_FIX.md
@@ -1,0 +1,271 @@
+# Websocket Tool Call Response - Solution for GitHub Issue #906
+
+## Problem Summary
+
+When using the Gemini Live API with websockets for function calling, the documentation mentions `BidiGenerateContentToolResponse` but doesn't clearly explain the correct format for sending function/tool responses back to the model. Many developers encounter connection closures or non-functional responses when trying to implement tool calling.
+
+## The Issue
+
+Users were struggling with:
+1. Unclear documentation about the `BidiGenerateContentToolResponse` format
+2. The field name `functionResponses[]` mentioned in docs not working
+3. Websocket connections closing when sending tool responses
+4. No clear examples of the working format for websockets
+
+## The Solution
+
+There are **TWO working formats** for sending tool responses via websockets:
+
+### Method 1: Using `tool_response` (Recommended)
+
+This is the format used in the official cookbook examples and is the recommended approach:
+
+```json
+{
+  "tool_response": {
+    "function_responses": [
+      {
+        "id": "<function_call_id>",
+        "name": "<function_name>",
+        "response": {
+          "result": <your_result_data>
+        }
+      }
+    ]
+  }
+}
+```
+
+**Python Example:**
+```python
+response_msg = {
+    "tool_response": {
+        "function_responses": [
+            {
+                "id": function_id,
+                "name": function_name,
+                "response": {"result": result}
+            }
+        ]
+    }
+}
+await ws.send(json.dumps(response_msg))
+```
+
+### Method 2: Using `clientContent` with `functionResponse`
+
+This alternative format was suggested by community members and also works:
+
+```json
+{
+  "clientContent": {
+    "turns": [
+      {
+        "role": "user",
+        "parts": [
+          {
+            "functionResponse": {
+              "name": "<function_name>",
+              "response": {
+                "output": <your_result_data>
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "turnComplete": true
+  }
+}
+```
+
+**Python Example:**
+```python
+response_msg = {
+    "clientContent": {
+        "turns": [
+            {
+                "role": "user",
+                "parts": [
+                    {
+                        "functionResponse": {
+                            "name": function_name,
+                            "response": {
+                                "output": result
+                            }
+                        }
+                    }
+                ]
+            }
+        ],
+        "turnComplete": True
+    }
+}
+await ws.send(json.dumps(response_msg))
+```
+
+## Key Differences from Documentation
+
+**What DOESN'T work:**
+- ❌ `BidiGenerateContentToolResponse` as a top-level message type
+- ❌ `functionResponses` (without the nested structure)
+- ❌ Sending responses without proper structure
+
+**What DOES work:**
+- ✅ `tool_response` with nested `function_responses` array
+- ✅ `clientContent` with `functionResponse` in parts
+- ✅ Both methods require proper function ID and name matching
+
+## Complete Working Example
+
+See the full working example in:
+- [`Websocket_Tool_Call_Response_Example.py`](./Websocket_Tool_Call_Response_Example.py)
+
+This example demonstrates:
+- Proper websocket setup with tool declarations
+- Handling tool calls from the model
+- Sending tool responses back in the correct format
+- Multiple function calls in sequence
+- Error handling
+
+## Code Comparison
+
+### SDK vs Websockets
+
+**With SDK (google-genai):**
+```python
+from google import genai
+from google.genai import types
+
+# Function response is simple
+function_response = types.FunctionResponse(
+    id=fc.id,
+    name=fc.name,
+    response={"result": "ok"}
+)
+
+# Send it
+await session.send_tool_response(function_responses=[function_response])
+```
+
+**With Websockets:**
+```python
+import json
+
+# Must format as JSON with specific structure
+response_msg = {
+    "tool_response": {
+        "function_responses": [
+            {
+                "id": fc['id'],
+                "name": fc['name'],
+                "response": {"result": "ok"}
+            }
+        ]
+    }
+}
+
+# Send as JSON string
+await ws.send(json.dumps(response_msg))
+```
+
+## Tool Declaration Format
+
+When setting up the websocket session, declare your tools like this:
+
+```python
+setup_msg = {
+    "setup": {
+        "model": f"models/{model}",
+        "tools": [
+            {
+                "function_declarations": [
+                    {
+                        "name": "get_weather",
+                        "description": "Get the current weather for a location",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "location": {
+                                    "type": "string",
+                                    "description": "City and state"
+                                }
+                            },
+                            "required": ["location"]
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+}
+```
+
+## Handling Tool Calls
+
+When the model wants to call a function, you'll receive a message like:
+
+```json
+{
+  "toolCall": {
+    "functionCalls": [
+      {
+        "id": "abc123",
+        "name": "get_weather",
+        "args": {
+          "location": "San Francisco, CA"
+        }
+      }
+    ]
+  }
+}
+```
+
+Process it and send back the response using one of the two methods above.
+
+## Common Pitfalls
+
+1. **Forgetting the function ID**: Always include the `id` field from the original function call
+2. **Wrong nesting**: The response data must be nested correctly under `response.result` or `response.output`
+3. **Not setting turnComplete**: For the clientContent method, include `"turnComplete": true`
+4. **Sending as Python dict instead of JSON string**: Use `json.dumps()` to convert to string
+5. **Mismatched function names**: The response name must match the call name exactly
+
+## Testing Your Implementation
+
+Use this simple test to verify your tool responses work:
+
+```python
+async def test_tool_response():
+    async with connect(uri) as ws:
+        await setup_session(ws)
+        
+        # Send a message that should trigger a tool call
+        await send_user_message(ws, "What's the weather in London?")
+        
+        # Process responses - if you get a tool call and can respond
+        # without the websocket closing, it works!
+        await process_responses(ws)
+```
+
+## References
+
+- GitHub Issue: [#906](https://github.com/google-gemini/cookbook/issues/906)
+- Official Cookbook: [Get_started_LiveAPI_tools.ipynb](../../quickstarts/Get_started_LiveAPI_tools.ipynb)
+- Websocket Examples: [websockets/Get_started_LiveAPI_tools.ipynb](../../quickstarts/websockets/Get_started_LiveAPI_tools.ipynb)
+- API Documentation: [Live API Function Calling](https://ai.google.dev/api/live#FunctionResponse)
+
+## Credits
+
+- Solution identified by [@nmfisher](https://github.com/nmfisher) in issue #906
+- Cookbook examples by Google Gemini team
+- Community contributions and testing
+
+## Need Help?
+
+If you're still having issues:
+1. Check that your API key is valid
+2. Verify you're using the correct model (`gemini-2.0-flash-live-001`)
+3. Ensure your websocket URI is correct
+4. Review the complete example in `Websocket_Tool_Call_Response_Example.py`
+5. Open an issue in the [cookbook repository](https://github.com/google-gemini/cookbook/issues)

--- a/examples/WEBSOCKET_TOOL_RESPONSE_FIX.md
+++ b/examples/WEBSOCKET_TOOL_RESPONSE_FIX.md
@@ -1,6 +1,6 @@
 # Websocket Tool Call Response - Solution for GitHub Issue #906
 
-## Problem Summary
+## Problem summary
 
 When using the Gemini Live API with websockets for function calling, the documentation mentions `BidiGenerateContentToolResponse` but doesn't clearly explain the correct format for sending function/tool responses back to the model. Many developers encounter connection closures or non-functional responses when trying to implement tool calling.
 
@@ -12,7 +12,7 @@ Users were struggling with:
 3. Websocket connections closing when sending tool responses
 4. No clear examples of the working format for websockets
 
-## The Solution
+## The solution
 
 There are **TWO working formats** for sending tool responses via websockets:
 
@@ -104,7 +104,7 @@ response_msg = {
 await ws.send(json.dumps(response_msg))
 ```
 
-## Key Differences from Documentation
+## Key differences from documentation
 
 **What DOESN'T work:**
 - ❌ `BidiGenerateContentToolResponse` as a top-level message type
@@ -116,7 +116,7 @@ await ws.send(json.dumps(response_msg))
 - ✅ `clientContent` with `functionResponse` in parts
 - ✅ Both methods require proper function ID and name matching
 
-## Complete Working Example
+## Complete working example
 
 See the full working example in:
 - [`Websocket_Tool_Call_Response_Example.py`](./Websocket_Tool_Call_Response_Example.py)
@@ -128,7 +128,7 @@ This example demonstrates:
 - Multiple function calls in sequence
 - Error handling
 
-## Code Comparison
+## Code comparison
 
 ### SDK vs Websockets
 
@@ -169,7 +169,7 @@ response_msg = {
 await ws.send(json.dumps(response_msg))
 ```
 
-## Tool Declaration Format
+## Tool declaration format
 
 When setting up the websocket session, declare your tools like this:
 
@@ -201,7 +201,7 @@ setup_msg = {
 }
 ```
 
-## Handling Tool Calls
+## Handling tool calls
 
 When the model wants to call a function, you'll receive a message like:
 
@@ -223,7 +223,7 @@ When the model wants to call a function, you'll receive a message like:
 
 Process it and send back the response using one of the two methods above.
 
-## Common Pitfalls
+## Common pitfalls
 
 1. **Forgetting the function ID**: Always include the `id` field from the original function call
 2. **Wrong nesting**: The response data must be nested correctly under `response.result` or `response.output`
@@ -231,7 +231,7 @@ Process it and send back the response using one of the two methods above.
 4. **Sending as Python dict instead of JSON string**: Use `json.dumps()` to convert to string
 5. **Mismatched function names**: The response name must match the call name exactly
 
-## Testing Your Implementation
+## Testing your implementation
 
 Use this simple test to verify your tool responses work:
 
@@ -261,7 +261,7 @@ async def test_tool_response():
 - Cookbook examples by Google Gemini team
 - Community contributions and testing
 
-## Need Help?
+## Need help?
 
 If you're still having issues:
 1. Check that your API key is valid

--- a/examples/Websocket_Tool_Call_Response_Example.py
+++ b/examples/Websocket_Tool_Call_Response_Example.py
@@ -1,0 +1,351 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Example: Handling Tool Call Responses with Gemini Live API Websockets
+
+This example demonstrates the CORRECT way to send function/tool call responses
+back to the Gemini Live API using websockets.
+
+## The Issue (GitHub #906)
+The documentation mentions BidiGenerateContentToolResponse, but the actual
+format that works is different. This example shows the working solution.
+
+## Setup
+
+Install dependencies:
+```
+pip install websockets
+```
+
+Set your API key:
+```
+export GOOGLE_API_KEY="your-api-key"
+```
+
+## Run
+```
+python Websocket_Tool_Call_Response_Example.py
+```
+"""
+
+import asyncio
+import json
+import os
+from websockets.asyncio.client import connect
+
+# Configuration
+GOOGLE_API_KEY = os.environ.get("GOOGLE_API_KEY")
+if not GOOGLE_API_KEY:
+    raise ValueError("GOOGLE_API_KEY environment variable must be set")
+
+host = "generativelanguage.googleapis.com"
+model = "gemini-2.0-flash-live-001"
+uri = f"wss://{host}/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent?key={GOOGLE_API_KEY}"
+
+
+# Example tool functions
+def get_weather(location: str) -> dict:
+    """Mock function to get weather information."""
+    return {
+        "location": location,
+        "temperature": "72°F",
+        "condition": "Sunny",
+        "humidity": "45%"
+    }
+
+
+def turn_on_lights() -> dict:
+    """Mock function to turn on lights."""
+    return {"status": "success", "message": "Lights turned on"}
+
+
+def turn_off_lights() -> dict:
+    """Mock function to turn off lights."""
+    return {"status": "success", "message": "Lights turned off"}
+
+
+# Tool registry mapping function names to implementations
+TOOL_REGISTRY = {
+    "get_weather": get_weather,
+    "turn_on_lights": turn_on_lights,
+    "turn_off_lights": turn_off_lights,
+}
+
+
+async def setup_session(ws):
+    """Initialize the websocket session with model configuration and tools."""
+    setup_msg = {
+        "setup": {
+            "model": f"models/{model}",
+            "generation_config": {
+                "response_modalities": ["TEXT"]
+            },
+            "tools": [
+                {
+                    "function_declarations": [
+                        {
+                            "name": "get_weather",
+                            "description": "Get the current weather for a location",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {
+                                    "location": {
+                                        "type": "string",
+                                        "description": "The city and state, e.g. San Francisco, CA"
+                                    }
+                                },
+                                "required": ["location"]
+                            }
+                        },
+                        {
+                            "name": "turn_on_lights",
+                            "description": "Turn on the lights"
+                        },
+                        {
+                            "name": "turn_off_lights",
+                            "description": "Turn off the lights"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+    
+    print("📤 Sending setup message...")
+    await ws.send(json.dumps(setup_msg))
+    
+    # Wait for setup confirmation
+    raw_response = await ws.recv(decode=False)
+    setup_response = json.loads(raw_response.decode("ascii"))
+    print("✅ Setup complete:", setup_response)
+    return setup_response
+
+
+async def send_user_message(ws, text: str):
+    """Send a user message to the model."""
+    msg = {
+        "client_content": {
+            "turns": [
+                {
+                    "role": "user",
+                    "parts": [{"text": text}]
+                }
+            ],
+            "turn_complete": True
+        }
+    }
+    print(f"\n📤 User: {text}")
+    await ws.send(json.dumps(msg))
+
+
+async def handle_tool_call(ws, tool_call: dict):
+    """
+    Handle tool calls from the model.
+    
+    CRITICAL: The correct format for tool responses is:
+    {
+        "tool_response": {
+            "function_responses": [
+                {
+                    "id": "<function_call_id>",
+                    "name": "<function_name>",
+                    "response": {
+                        "result": <your_result_data>
+                    }
+                }
+            ]
+        }
+    }
+    
+    DO NOT use "BidiGenerateContentToolResponse" - it doesn't work!
+    
+    Alternative format (as suggested in the GitHub issue):
+    {
+        "clientContent": {
+            "turns": [
+                {
+                    "role": "user",
+                    "parts": [
+                        {
+                            "functionResponse": {
+                                "name": "<function_name>",
+                                "response": {
+                                    "output": <your_result_data>
+                                }
+                            }
+                        }
+                    ]
+                }
+            ],
+            "turnComplete": true
+        }
+    }
+    """
+    print("\n🔧 Tool calls received:")
+    
+    function_calls = tool_call.get('functionCalls', [])
+    
+    # Process each function call
+    for fc in function_calls:
+        function_name = fc['name']
+        function_id = fc['id']
+        function_args = fc.get('args', {})
+        
+        print(f"  • {function_name}({function_args})")
+        
+        # Execute the function
+        if function_name in TOOL_REGISTRY:
+            try:
+                # Get the function and call it with the arguments
+                func = TOOL_REGISTRY[function_name]
+                result = func(**function_args)
+                print(f"    ✓ Result: {result}")
+                
+                # METHOD 1: Using tool_response (preferred based on cookbook examples)
+                response_msg = {
+                    "tool_response": {
+                        "function_responses": [
+                            {
+                                "id": function_id,
+                                "name": function_name,
+                                "response": {"result": result}
+                            }
+                        ]
+                    }
+                }
+                
+                # METHOD 2: Using clientContent with functionResponse (alternative)
+                # Uncomment to use this method instead:
+                # response_msg = {
+                #     "clientContent": {
+                #         "turns": [
+                #             {
+                #                 "role": "user",
+                #                 "parts": [
+                #                     {
+                #                         "functionResponse": {
+                #                             "name": function_name,
+                #                             "response": {
+                #                                 "output": result
+                #                             }
+                #                         }
+                #                     }
+                #                 ]
+                #             }
+                #         ],
+                #         "turnComplete": True
+                #     }
+                # }
+                
+                print(f"📤 Sending tool response: {json.dumps(response_msg, indent=2)}")
+                await ws.send(json.dumps(response_msg))
+                
+            except Exception as e:
+                print(f"    ✗ Error executing {function_name}: {e}")
+                # Send error response
+                error_response = {
+                    "tool_response": {
+                        "function_responses": [
+                            {
+                                "id": function_id,
+                                "name": function_name,
+                                "response": {
+                                    "result": {
+                                        "error": str(e)
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+                await ws.send(json.dumps(error_response))
+        else:
+            print(f"    ✗ Unknown function: {function_name}")
+
+
+async def process_responses(ws):
+    """Process responses from the model."""
+    async for raw_response in ws:
+        response = json.loads(raw_response.decode("ascii"))
+        
+        # Handle server content (text responses)
+        server_content = response.get("serverContent")
+        if server_content:
+            model_turn = server_content.get("modelTurn")
+            if model_turn:
+                parts = model_turn.get("parts", [])
+                for part in parts:
+                    if "text" in part:
+                        print(f"🤖 Model: {part['text']}")
+            
+            # Check if turn is complete
+            if server_content.get("turnComplete"):
+                print("\n✓ Turn complete\n")
+                break
+        
+        # Handle tool calls
+        tool_call = response.get("toolCall")
+        if tool_call:
+            await handle_tool_call(ws, tool_call)
+
+
+async def main():
+    """Main function demonstrating tool call handling."""
+    print("=" * 70)
+    print("Gemini Live API - Websocket Tool Call Response Example")
+    print("=" * 70)
+    
+    async with connect(
+        uri, 
+        additional_headers={"Content-Type": "application/json"}
+    ) as ws:
+        # Setup session
+        await setup_session(ws)
+        
+        # Example 1: Simple function call
+        print("\n" + "=" * 70)
+        print("Example 1: Simple weather query")
+        print("=" * 70)
+        await send_user_message(ws, "What's the weather in San Francisco?")
+        await process_responses(ws)
+        
+        # Example 2: Multiple function calls
+        print("\n" + "=" * 70)
+        print("Example 2: Multiple function calls")
+        print("=" * 70)
+        await send_user_message(
+            ws, 
+            "Turn on the lights and tell me the weather in New York"
+        )
+        await process_responses(ws)
+        
+        # Example 3: Function call with follow-up
+        print("\n" + "=" * 70)
+        print("Example 3: Function call with follow-up")
+        print("=" * 70)
+        await send_user_message(ws, "Get the weather for London")
+        await process_responses(ws)
+        
+        await send_user_message(ws, "Is that good weather?")
+        await process_responses(ws)
+        
+    print("\n" + "=" * 70)
+    print("✓ Example completed successfully!")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/Websocket_Tool_Call_Response_Example.py
+++ b/examples/Websocket_Tool_Call_Response_Example.py
@@ -253,7 +253,7 @@ async def handle_tool_call(ws, tool_call: dict):
                 print(f"📤 Sending tool response: {json.dumps(response_msg, indent=2)}")
                 await ws.send(json.dumps(response_msg))
                 
-            except Exception as e:
+            except TypeError as e:
                 print(f"    ✗ Error executing {function_name}: {e}")
                 # Send error response
                 error_response = {

--- a/examples/Websocket_Tool_Call_Response_Example.py
+++ b/examples/Websocket_Tool_Call_Response_Example.py
@@ -41,6 +41,7 @@ python Websocket_Tool_Call_Response_Example.py
 ```
 """
 
+import argparse
 import asyncio
 import json
 import os
@@ -52,7 +53,6 @@ if not GOOGLE_API_KEY:
     raise ValueError("GOOGLE_API_KEY environment variable must be set")
 
 host = "generativelanguage.googleapis.com"
-model = "gemini-2.0-flash-live-001"
 uri = f"wss://{host}/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent?key={GOOGLE_API_KEY}"
 
 
@@ -85,7 +85,7 @@ TOOL_REGISTRY = {
 }
 
 
-async def setup_session(ws):
+async def setup_session(ws, model="gemini-2.0-flash-live-001"):
     """Initialize the websocket session with model configuration and tools."""
     setup_msg = {
         "setup": {
@@ -302,10 +302,11 @@ async def process_responses(ws):
             await handle_tool_call(ws, tool_call)
 
 
-async def main():
+async def main(model="gemini-2.0-flash-live-001"):
     """Main function demonstrating tool call handling."""
     print("=" * 70)
     print("Gemini Live API - Websocket Tool Call Response Example")
+    print(f"Using model: {model}")
     print("=" * 70)
     
     async with connect(
@@ -313,7 +314,7 @@ async def main():
         additional_headers={"Content-Type": "application/json"}
     ) as ws:
         # Setup session
-        await setup_session(ws)
+        await setup_session(ws, model)
         
         # Example 1: Simple function call
         print("\n" + "=" * 70)
@@ -348,4 +349,15 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    parser = argparse.ArgumentParser(
+        description="Websocket tool response example for Gemini Live API"
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="gemini-2.0-flash-live-001",
+        help="The model to use (default: gemini-2.0-flash-live-001)",
+    )
+    args = parser.parse_args()
+    
+    asyncio.run(main(args.model))


### PR DESCRIPTION
Hey! This fixes issue #906.

I ran into the same problem many others reported: the docs mention `BidiGenerateContentToolResponse`, but they don’t clearly show how to format a tool response when using WebSockets. I tried several approaches, but the WebSocket kept closing unexpectedly.

WHAT I ADDED

Two files to make WebSocket function calling actually usable end-to-end:

1) Websocket_Tool_Call_Response_Example.py  
A complete, runnable example. You just need to add your API key.
It shows:
- How to set up a WebSocket connection with tools enabled
- How to detect and handle a function call
- Two different (working) ways to send the tool response back
- Example tools (weather lookup, turning lights on/off)

2) WEBSOCKET_TOOL_RESPONSE_FIX.md  
A practical guide covering:
- What works and what doesn’t
- Common mistakes that cause WebSocket disconnects
- Subtleties missing from the current docs

THE ACTUAL SOLUTION

There are two formats that work for sending tool responses over WebSockets.

OPTION 1 (used in the cookbook examples)

    response_msg = {
        "tool_response": {
            "function_responses": [{
                "id": function_call_id,
                "name": function_name,
                "response": {"result": your_data}
            }]
        }
    }

OPTION 2 (based on @nmfisher’s workaround in the issue)

    response_msg = {
        "clientContent": {
            "turns": [{
                "role": "user",
                "parts": [{
                    "functionResponse": {
                        "name": function_name,
                        "response": {"output": your_data}
                    }
                }]
            }],
            "turnComplete": True
        }
    }

Both formats work reliably. I’ve been using Option 1 since it matches the cookbook examples.

WHAT DOES NOT WORK

The following consistently caused failures or WebSocket closures:
- Trying to use BidiGenerateContentToolResponse directly
- Forgetting the function call ID
- Not matching the function name exactly
- Sending a Python dict instead of a JSON-encoded string

TESTED SCENARIOS

Tested with:
- Single function calls
- Multiple function calls in a single turn
- Follow-up model responses after a function call
