### PR TITLE
Add Self-Improving Prompts notebook

### DIFF
--- a/examples/prompting/README.md
+++ b/examples/prompting/README.md
@@ -28,6 +28,8 @@ Here's a breakdown of the notebooks available and the concepts they cover:
 
 *   **[`Self_ask_prompting.ipynb`](./Self_ask_prompting.ipynb):** Demonstrates a technique where the model asks itself questions to help answer the query.
 
+*   **[`Self_Improving_Prompts.ipynb`](./Self_Improving_Prompts.ipynb):** Demonstrates using Gemini to critique and improve prompts through iterative self-refinement.
+
 *   **[`Zero_shot_prompting.ipynb`](./Zero_shot_prompting.ipynb):** Demonstrates prompting the model *without* any specific examples.
 
 ## General Tips

--- a/examples/prompting/Self_Improving_Prompts.ipynb
+++ b/examples/prompting/Self_Improving_Prompts.ipynb
@@ -1,0 +1,651 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Tce3stUlHN0L"
+   },
+   "source": [
+    "##### Copyright 2025 Google LLC."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "cellView": "form",
+    "id": "tuOe1ymfHZPu"
+   },
+   "outputs": [],
+   "source": [
+    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "# https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "qFdPvlXBOdUN"
+   },
+   "source": [
+    "# Gemini API: Self-Improving Prompts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "MfBg1C5NB3X0"
+   },
+   "source": [
+    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/google-gemini/cookbook/blob/main/examples/prompting/Self_Improving_Prompts.ipynb\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" height=30/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "XCVydW40iixa"
+   },
+   "source": [
+    "<table>\n",
+    "  <tr>\n",
+    "    <td bgcolor=\"#d7e6ff\">\n",
+    "      <a href=\"https://github.com/Karanjot786\" target=\"_blank\" title=\"View profile on GitHub\">\n",
+    "        <img src=\"https://github.com/Karanjot786.png?size=100\"\n",
+    "             alt=\"Karanjot786's GitHub avatar\"\n",
+    "             width=\"100\"\n",
+    "             height=\"100\">\n",
+    "      </a>\n",
+    "    </td>\n",
+    "    <td bgcolor=\"#d7e6ff\">\n",
+    "      <h2><font color='black'>This notebook was contributed by <a href=\"https://github.com/Karanjot786\" target=\"_blank\"><font color='#217bfe'><strong>Karanjot786</strong></font></a>.</font></h2>\n",
+    "      <h5><font color='black'>See <a href=\"https://github.com/Karanjot786\" target=\"_blank\"><font color=\"#078efb\"><strong>Karanjot786</strong></font></a> other notebooks <a href=\"https://github.com/search?q=repo%3Agoogle-gemini%2Fcookbook%20%22Karanjot786%22&type=code\" target=\"_blank\"><font color=\"#078efb\">here</font></a>.</h5></font><br>\n",
+    "      <font color='black'><small><em>Have a cool Gemini example? Feel free to <a href=\"https://github.com/google-gemini/cookbook/blob/main/CONTRIBUTING.md\" target=\"_blank\"><font color=\"#078efb\">share it too</font></a>!</em></small></font>\n",
+    "    </td>\n",
+    "  </tr>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "xHxb-dlhMIzW"
+   },
+   "source": [
+    "Prompt engineering often involves trial and error. You write a prompt, check the output, then manually tweak the prompt until it works.\n",
+    "\n",
+    "This notebook shows a different approach: let Gemini improve the prompt for you.\n",
+    "\n",
+    "The self-improving prompts pattern works like this:\n",
+    "1. Run an initial prompt\n",
+    "2. Have Gemini critique the output\n",
+    "3. Have Gemini rewrite the prompt based on the critique\n",
+    "4. Run the improved prompt\n",
+    "5. Repeat until satisfied\n",
+    "\n",
+    "This technique is useful when:\n",
+    "- You have a rough idea but need to refine it\n",
+    "- You want to understand what makes a prompt effective\n",
+    "- You need to optimize prompts at scale"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "monLpKy7423V"
+   },
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "id": "AQJjzmYgH3sX"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install -U -q \"google-genai>=1.0.0\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "85166363b66b"
+   },
+   "source": [
+    "Select the model you want to use:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "id": "6fd823b1bd4e"
+   },
+   "outputs": [],
+   "source": [
+    "MODEL_ID = \"gemini-3-flash-preview\" # @param [\"gemini-2.5-flash-lite\", \"gemini-2.5-flash\", \"gemini-2.5-pro\", \"gemini-3-flash-preview\", \"gemini-3-pro-preview\"] {\"allow-input\":true, isTemplate: true}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "MUXex9ctTuDB"
+   },
+   "source": [
+    "### Configure your API key\n",
+    "\n",
+    "To run the following cell, your API key must be stored in a Colab Secret named `GOOGLE_API_KEY`. If you don't already have an API key, or you're not sure how to create a Colab Secret, see [Authentication](https://github.com/google-gemini/cookbook/blob/main/quickstarts/Authentication.ipynb) for an example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "id": "wltbMJLIIXGk"
+   },
+   "outputs": [],
+   "source": [
+    "from google.colab import userdata\n",
+    "from google import genai\n",
+    "\n",
+    "GOOGLE_API_KEY = userdata.get('GOOGLE_API_KEY')\n",
+    "client = genai.Client(api_key=GOOGLE_API_KEY)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "section1"
+   },
+   "source": [
+    "## Step 1: Start with a weak prompt\n",
+    "\n",
+    "Start with a simple prompt that produces okay results. The goal is to see how much Gemini can improve it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "id": "code1"
+   },
+   "outputs": [],
+   "source": [
+    "weak_prompt = \"\"\"\n",
+    "Summarize this text:\n",
+    "\n",
+    "The quick brown fox jumps over the lazy dog. The dog was not really lazy, \n",
+    "it was just tired from playing all day. The fox was looking for food and \n",
+    "saw the dog sleeping. The fox jumped over to get to the other side of the \n",
+    "yard where there was a chicken coop. The chickens were scared but the fox \n",
+    "did not catch any of them. The farmer heard the noise and came out. The \n",
+    "fox ran away. The dog woke up and barked at the fox.\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "section2"
+   },
+   "source": [
+    "## Step 2: Run the weak prompt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "id": "code2"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Initial output:\n",
+      "A hungry fox jumped over a tired, sleeping dog to reach a chicken coop. However, the fox failed to catch any chickens because the farmer was alerted by the noise and chased him away.\n"
+     ]
+    }
+   ],
+   "source": [
+    "initial_response = client.models.generate_content(\n",
+    "    model=MODEL_ID,\n",
+    "    contents=weak_prompt\n",
+    ")\n",
+    "\n",
+    "initial_output = initial_response.text\n",
+    "print(\"Initial output:\")\n",
+    "print(initial_output)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "section3"
+   },
+   "source": [
+    "## Step 3: Have Gemini critique the prompt\n",
+    "\n",
+    "Ask Gemini to analyze what is missing or unclear in the original prompt."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "id": "code3"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Critique:\n",
+      "As a prompt engineering expert, here is a critique of your prompt:\n",
+      "\n",
+      "### 1. What is missing from the prompt\n",
+      "*   **Constraints:** There are no limits on length (e.g., \"in under 20 words,\" \"in one sentence,\" or \"in three bullet points\").\n",
+      "*   **Format:** The prompt doesn’t specify a desired structure (e.g., a formal paragraph, a narrative hook, or a TL;DR).\n",
+      "*   **Persona/Audience:** There is no context regarding who the summary is for (e.g., \"summarize for a child\" vs. \"summarize for a data analyst\").\n",
+      "*   **Tone:** The prompt lacks stylistic guidance (e.g., \"playful,\" \"objective,\" or \"suspenseful\").\n",
+      "\n",
+      "### 2. What is unclear or ambiguous\n",
+      "*   **The \"Summarize\" Instruction:** The word \"summarize\" is a \"weak\" verb because it is subjective. Without specific parameters, the AI guesses the level of detail. It is unclear whether you want a high-level theme (a fox's failed hunt) or a chronological retelling of events.\n",
+      "*   **Information Hierarchy:** The prompt doesn't state what to prioritize (e.g., the fox's motivation, the dog's reaction, or the farmer’s intervention).\n",
+      "\n",
+      "### 3. How the output could be improved\n",
+      "While the current output is factually accurate, it could be improved by:\n",
+      "*   **Including Narrative Resolution:** The current output stops at the farmer, missing the final beat where the dog wakes up and reacts.\n",
+      "*   **Better Flow:** The transition \"However\" is slightly formal for a simple fable; a more narrative flow would feel more natural.\n",
+      "*   **Varying Detail:** Depending on the goal, the output might be too long. A \"One-sentence summary\" would be more punchy for a quick read.\n",
+      "\n",
+      "---\n",
+      "\n",
+      "### Recommended Improved Prompt\n",
+      "> **Role:** You are a children's story editor. \n",
+      "> **Task:** Summarize the provided text into a single, engaging sentence of no more than 25 words. \n",
+      "> **Tone:** Whimsical and narrative.\n",
+      "> **Constraint:** Ensure you mention the fox’s goal and the ultimate outcome for both the fox and the dog.\n",
+      ">\n",
+      "> **Text:** [Insert Text Here]\n"
+     ]
+    }
+   ],
+   "source": [
+    "critique_prompt = f\"\"\"\n",
+    "You are a prompt engineering expert.\n",
+    "\n",
+    "Here is a prompt:\n",
+    "---\n",
+    "{weak_prompt}\n",
+    "---\n",
+    "\n",
+    "Here is the output it produced:\n",
+    "---\n",
+    "{initial_output}\n",
+    "---\n",
+    "\n",
+    "Critique this prompt. Identify:\n",
+    "1. What is missing from the prompt\n",
+    "2. What is unclear or ambiguous\n",
+    "3. How the output could be improved\n",
+    "\n",
+    "Be specific and concise. Focus on actionable improvements.\n",
+    "\"\"\"\n",
+    "\n",
+    "critique_response = client.models.generate_content(\n",
+    "    model=MODEL_ID,\n",
+    "    contents=critique_prompt\n",
+    ")\n",
+    "\n",
+    "critique = critique_response.text\n",
+    "print(\"Critique:\")\n",
+    "print(critique)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "section4"
+   },
+   "source": [
+    "## Step 4: Have Gemini rewrite the prompt\n",
+    "\n",
+    "Based on the critique, ask Gemini to write a better version of the prompt."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "id": "code4"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Improved prompt:\n",
+      "Role: Children's story editor. \n",
+      "Task: Summarize the provided text into a single, engaging sentence of no more than 25 words. \n",
+      "Tone: Whimsical and narrative.\n",
+      "Constraint: Ensure you mention the fox’s goal and the ultimate outcome for both the fox and the dog.\n",
+      "\n",
+      "Text: \n",
+      "The quick brown fox jumps over the lazy dog. The dog was not really lazy, it was just tired from playing all day. The fox was looking for food and saw the dog sleeping. The fox jumped over to get to the other side of the yard where there was a chicken coop. The chickens were scared but the fox did not catch any of them. The farmer heard the noise and came out. The fox ran away. The dog woke up and barked at the fox.\n"
+     ]
+    }
+   ],
+   "source": [
+    "rewrite_prompt = f\"\"\"\n",
+    "Based on the following critique, rewrite the original prompt to produce \n",
+    "a better output.\n",
+    "\n",
+    "Original prompt:\n",
+    "---\n",
+    "{weak_prompt}\n",
+    "---\n",
+    "\n",
+    "Critique:\n",
+    "---\n",
+    "{critique}\n",
+    "---\n",
+    "\n",
+    "Write the improved prompt. Output only the new prompt text, nothing else.\n",
+    "\"\"\"\n",
+    "\n",
+    "rewrite_response = client.models.generate_content(\n",
+    "    model=MODEL_ID,\n",
+    "    contents=rewrite_prompt\n",
+    ")\n",
+    "\n",
+    "improved_prompt = rewrite_response.text\n",
+    "print(\"Improved prompt:\")\n",
+    "print(improved_prompt)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "section5"
+   },
+   "source": [
+    "## Step 5: Run the improved prompt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "id": "code5"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Improved output:\n",
+      "To reach the chickens, the fox vaulted over the dozing dog, but fled empty-pawed once the farmer appeared and the pup woke to bark.\n"
+     ]
+    }
+   ],
+   "source": [
+    "improved_response = client.models.generate_content(\n",
+    "    model=MODEL_ID,\n",
+    "    contents=improved_prompt\n",
+    ")\n",
+    "\n",
+    "improved_output = improved_response.text\n",
+    "print(\"Improved output:\")\n",
+    "print(improved_output)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "section6"
+   },
+   "source": [
+    "## Step 6: Compare before and after"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "id": "code6"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==================================================\n",
+      "BEFORE (weak prompt):\n",
+      "A hungry fox jumped over a tired, sleeping dog to reach a chicken coop. However, the fox failed to catch any chickens because the farmer was alerted by the noise and chased him away.\n",
+      "==================================================\n",
+      "AFTER (improved prompt):\n",
+      "To reach the chickens, the fox vaulted over the dozing dog, but fled empty-pawed once the farmer appeared and the pup woke to bark.\n",
+      "==================================================\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"=\" * 50)\n",
+    "print(\"BEFORE (weak prompt):\")\n",
+    "print(initial_output)\n",
+    "print(\"=\" * 50)\n",
+    "print(\"AFTER (improved prompt):\")\n",
+    "print(improved_output)\n",
+    "print(\"=\" * 50)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "section7"
+   },
+   "source": [
+    "## Create a reusable function\n",
+    "\n",
+    "Wrap the self-improvement loop into a function you can use with any prompt."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "id": "code7"
+   },
+   "outputs": [],
+   "source": [
+    "def improve_prompt(original_prompt, iterations=2, verbose=True):\n",
+    "    \"\"\"\n",
+    "    Iteratively improve a prompt using Gemini self-critique.\n",
+    "\n",
+    "    Args:\n",
+    "        original_prompt: The initial prompt to improve\n",
+    "        iterations: Number of improvement cycles (default: 2)\n",
+    "        verbose: Print progress (default: True)\n",
+    "\n",
+    "    Returns:\n",
+    "        Tuple of (final_prompt, final_output)\n",
+    "    \"\"\"\n",
+    "    current_prompt = original_prompt\n",
+    "\n",
+    "    for i in range(iterations):\n",
+    "        # Run current prompt\n",
+    "        output = client.models.generate_content(\n",
+    "            model=MODEL_ID,\n",
+    "            contents=current_prompt\n",
+    "        ).text\n",
+    "\n",
+    "        # Critique\n",
+    "        critique = client.models.generate_content(\n",
+    "            model=MODEL_ID,\n",
+    "            contents=f\"\"\"\n",
+    "            Critique this prompt and its output. Be specific and actionable.\n",
+    "\n",
+    "            Prompt:\n",
+    "            {current_prompt}\n",
+    "\n",
+    "            Output:\n",
+    "            {output}\n",
+    "            \"\"\"\n",
+    "        ).text\n",
+    "\n",
+    "        # Rewrite\n",
+    "        current_prompt = client.models.generate_content(\n",
+    "            model=MODEL_ID,\n",
+    "            contents=f\"\"\"\n",
+    "            Rewrite this prompt based on the critique.\n",
+    "            Output only the new prompt text.\n",
+    "\n",
+    "            Original prompt:\n",
+    "            {current_prompt}\n",
+    "\n",
+    "            Critique:\n",
+    "            {critique}\n",
+    "            \"\"\"\n",
+    "        ).text\n",
+    "\n",
+    "        if verbose:\n",
+    "            print(f\"Iteration {i + 1} complete\")\n",
+    "\n",
+    "    # Final run\n",
+    "    final_output = client.models.generate_content(\n",
+    "        model=MODEL_ID,\n",
+    "        contents=current_prompt\n",
+    "    ).text\n",
+    "\n",
+    "    return current_prompt, final_output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "section8"
+   },
+   "source": [
+    "## Test the function with a new example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "id": "code8"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration 1 complete\n",
+      "Iteration 2 complete\n",
+      "\n",
+      "FINAL PROMPT:\n",
+      "Write a Petrarchan sonnet in strict iambic pentameter with a weary, introspective tone about the quiet satisfaction of refactoring a bloated legacy codebase into clean, PEP 8-compliant Python. Avoid clichés like \"dark rooms\" or \"missing semicolons\"; instead, use grounded metaphors of architectural restoration or pruning a wild garden—stripping the scaffolding from brittle functions or thinning out overgrown, deep indentations. Focus on the physical relief of deleting redundant lines and the mental clarity provided by specific Pythonic nuances, such as replacing tangled globals with pure-built functions, the order of clean imports, and the serene breath of a concise docstring.\n",
+      "\n",
+      "FINAL OUTPUT:\n",
+      "I peel the brittle layers from the frame,\n",
+      "Where nested loops once choked the morning light.\n",
+      "This tangled sprawl, a vast and jagged sight,\n",
+      "Had buried every purpose in its name.\n",
+      "I strip the scaffold from the ancient shame\n",
+      "Of global states that rotted in the night;\n",
+      "I prune the deep indent, the thicket’s height,\n",
+      "And bring the wild to heel, precise and tame.\n",
+      "\n",
+      "Now alphabetic imports stand in line\n",
+      "To grant the way to functions’ pure intent.\n",
+      "I purge the bloat, the ghost of errors past;\n",
+      "The docstring, brief, in form so crystalline,\n",
+      "Restores the quiet grace of what was meant.\n",
+      "The screen is light; I am at peace at last.\n"
+     ]
+    }
+   ],
+   "source": [
+    "test_prompt = \"Write a poem about coding.\"\n",
+    "\n",
+    "final_prompt, final_output = improve_prompt(test_prompt, iterations=2)\n",
+    "\n",
+    "print(\"\\nFINAL PROMPT:\")\n",
+    "print(final_prompt)\n",
+    "print(\"\\nFINAL OUTPUT:\")\n",
+    "print(final_output)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "nextsteps"
+   },
+   "source": [
+    "## Next steps\n",
+    "\n",
+    "### Related notebooks\n",
+    "\n",
+    "- [Chain of thought prompting](./Chain_of_thought_prompting.ipynb)\n",
+    "- [Self-ask prompting](./Self_ask_prompting.ipynb)\n",
+    "- [Few-shot prompting](./Few_shot_prompting.ipynb)\n",
+    "\n",
+    "### Ideas to extend this pattern\n",
+    "\n",
+    "- Add a scoring function to measure improvement\n",
+    "- Use multiple Gemini models (one for critique, one for rewriting)\n",
+    "- Store improvement history for analysis\n",
+    "- Combine with few-shot examples for domain-specific optimization"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [
+    "Tce3stUlHN0L"
+   ],
+   "name": "Self_Improving_Prompts.ipynb",
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/prompting/Self_Improving_Prompts.ipynb
+++ b/examples/prompting/Self_Improving_Prompts.ipynb
@@ -1,651 +1,632 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "Tce3stUlHN0L"
-   },
-   "source": [
-    "##### Copyright 2025 Google LLC."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "cellView": "form",
-    "id": "tuOe1ymfHZPu"
-   },
-   "outputs": [],
-   "source": [
-    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-    "# you may not use this file except in compliance with the License.\n",
-    "# You may obtain a copy of the License at\n",
-    "#\n",
-    "# https://www.apache.org/licenses/LICENSE-2.0\n",
-    "#\n",
-    "# Unless required by applicable law or agreed to in writing, software\n",
-    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-    "# See the License for the specific language governing permissions and\n",
-    "# limitations under the License."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "qFdPvlXBOdUN"
-   },
-   "source": [
-    "# Gemini API: Self-Improving Prompts"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "MfBg1C5NB3X0"
-   },
-   "source": [
-    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/google-gemini/cookbook/blob/main/examples/prompting/Self_Improving_Prompts.ipynb\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" height=30/></a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "XCVydW40iixa"
-   },
-   "source": [
-    "<table>\n",
-    "  <tr>\n",
-    "    <td bgcolor=\"#d7e6ff\">\n",
-    "      <a href=\"https://github.com/Karanjot786\" target=\"_blank\" title=\"View profile on GitHub\">\n",
-    "        <img src=\"https://github.com/Karanjot786.png?size=100\"\n",
-    "             alt=\"Karanjot786's GitHub avatar\"\n",
-    "             width=\"100\"\n",
-    "             height=\"100\">\n",
-    "      </a>\n",
-    "    </td>\n",
-    "    <td bgcolor=\"#d7e6ff\">\n",
-    "      <h2><font color='black'>This notebook was contributed by <a href=\"https://github.com/Karanjot786\" target=\"_blank\"><font color='#217bfe'><strong>Karanjot786</strong></font></a>.</font></h2>\n",
-    "      <h5><font color='black'>See <a href=\"https://github.com/Karanjot786\" target=\"_blank\"><font color=\"#078efb\"><strong>Karanjot786</strong></font></a> other notebooks <a href=\"https://github.com/search?q=repo%3Agoogle-gemini%2Fcookbook%20%22Karanjot786%22&type=code\" target=\"_blank\"><font color=\"#078efb\">here</font></a>.</h5></font><br>\n",
-    "      <font color='black'><small><em>Have a cool Gemini example? Feel free to <a href=\"https://github.com/google-gemini/cookbook/blob/main/CONTRIBUTING.md\" target=\"_blank\"><font color=\"#078efb\">share it too</font></a>!</em></small></font>\n",
-    "    </td>\n",
-    "  </tr>\n",
-    "</table>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "xHxb-dlhMIzW"
-   },
-   "source": [
-    "Prompt engineering often involves trial and error. You write a prompt, check the output, then manually tweak the prompt until it works.\n",
-    "\n",
-    "This notebook shows a different approach: let Gemini improve the prompt for you.\n",
-    "\n",
-    "The self-improving prompts pattern works like this:\n",
-    "1. Run an initial prompt\n",
-    "2. Have Gemini critique the output\n",
-    "3. Have Gemini rewrite the prompt based on the critique\n",
-    "4. Run the improved prompt\n",
-    "5. Repeat until satisfied\n",
-    "\n",
-    "This technique is useful when:\n",
-    "- You have a rough idea but need to refine it\n",
-    "- You want to understand what makes a prompt effective\n",
-    "- You need to optimize prompts at scale"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "monLpKy7423V"
-   },
-   "source": [
-    "## Setup"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "id": "AQJjzmYgH3sX"
-   },
-   "outputs": [
+  "cells": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
-   "source": [
-    "%pip install -U -q \"google-genai>=1.0.0\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "85166363b66b"
-   },
-   "source": [
-    "Select the model you want to use:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "id": "6fd823b1bd4e"
-   },
-   "outputs": [],
-   "source": [
-    "MODEL_ID = \"gemini-3-flash-preview\" # @param [\"gemini-2.5-flash-lite\", \"gemini-2.5-flash\", \"gemini-2.5-pro\", \"gemini-3-flash-preview\", \"gemini-3-pro-preview\"] {\"allow-input\":true, isTemplate: true}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "MUXex9ctTuDB"
-   },
-   "source": [
-    "### Configure your API key\n",
-    "\n",
-    "To run the following cell, your API key must be stored in a Colab Secret named `GOOGLE_API_KEY`. If you don't already have an API key, or you're not sure how to create a Colab Secret, see [Authentication](https://github.com/google-gemini/cookbook/blob/main/quickstarts/Authentication.ipynb) for an example."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "id": "wltbMJLIIXGk"
-   },
-   "outputs": [],
-   "source": [
-    "from google.colab import userdata\n",
-    "from google import genai\n",
-    "\n",
-    "GOOGLE_API_KEY = userdata.get('GOOGLE_API_KEY')\n",
-    "client = genai.Client(api_key=GOOGLE_API_KEY)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "section1"
-   },
-   "source": [
-    "## Step 1: Start with a weak prompt\n",
-    "\n",
-    "Start with a simple prompt that produces okay results. The goal is to see how much Gemini can improve it."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "id": "code1"
-   },
-   "outputs": [],
-   "source": [
-    "weak_prompt = \"\"\"\n",
-    "Summarize this text:\n",
-    "\n",
-    "The quick brown fox jumps over the lazy dog. The dog was not really lazy, \n",
-    "it was just tired from playing all day. The fox was looking for food and \n",
-    "saw the dog sleeping. The fox jumped over to get to the other side of the \n",
-    "yard where there was a chicken coop. The chickens were scared but the fox \n",
-    "did not catch any of them. The farmer heard the noise and came out. The \n",
-    "fox ran away. The dog woke up and barked at the fox.\n",
-    "\"\"\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "section2"
-   },
-   "source": [
-    "## Step 2: Run the weak prompt"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "id": "code2"
-   },
-   "outputs": [
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Tce3stUlHN0L"
+      },
+      "source": [
+        "##### Copyright 2025 Google LLC."
+      ]
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Initial output:\n",
-      "A hungry fox jumped over a tired, sleeping dog to reach a chicken coop. However, the fox failed to catch any chickens because the farmer was alerted by the noise and chased him away.\n"
-     ]
-    }
-   ],
-   "source": [
-    "initial_response = client.models.generate_content(\n",
-    "    model=MODEL_ID,\n",
-    "    contents=weak_prompt\n",
-    ")\n",
-    "\n",
-    "initial_output = initial_response.text\n",
-    "print(\"Initial output:\")\n",
-    "print(initial_output)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "section3"
-   },
-   "source": [
-    "## Step 3: Have Gemini critique the prompt\n",
-    "\n",
-    "Ask Gemini to analyze what is missing or unclear in the original prompt."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "id": "code3"
-   },
-   "outputs": [
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "cellView": "form",
+        "id": "tuOe1ymfHZPu"
+      },
+      "outputs": [],
+      "source": [
+        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "# https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ]
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Critique:\n",
-      "As a prompt engineering expert, here is a critique of your prompt:\n",
-      "\n",
-      "### 1. What is missing from the prompt\n",
-      "*   **Constraints:** There are no limits on length (e.g., \"in under 20 words,\" \"in one sentence,\" or \"in three bullet points\").\n",
-      "*   **Format:** The prompt doesn’t specify a desired structure (e.g., a formal paragraph, a narrative hook, or a TL;DR).\n",
-      "*   **Persona/Audience:** There is no context regarding who the summary is for (e.g., \"summarize for a child\" vs. \"summarize for a data analyst\").\n",
-      "*   **Tone:** The prompt lacks stylistic guidance (e.g., \"playful,\" \"objective,\" or \"suspenseful\").\n",
-      "\n",
-      "### 2. What is unclear or ambiguous\n",
-      "*   **The \"Summarize\" Instruction:** The word \"summarize\" is a \"weak\" verb because it is subjective. Without specific parameters, the AI guesses the level of detail. It is unclear whether you want a high-level theme (a fox's failed hunt) or a chronological retelling of events.\n",
-      "*   **Information Hierarchy:** The prompt doesn't state what to prioritize (e.g., the fox's motivation, the dog's reaction, or the farmer’s intervention).\n",
-      "\n",
-      "### 3. How the output could be improved\n",
-      "While the current output is factually accurate, it could be improved by:\n",
-      "*   **Including Narrative Resolution:** The current output stops at the farmer, missing the final beat where the dog wakes up and reacts.\n",
-      "*   **Better Flow:** The transition \"However\" is slightly formal for a simple fable; a more narrative flow would feel more natural.\n",
-      "*   **Varying Detail:** Depending on the goal, the output might be too long. A \"One-sentence summary\" would be more punchy for a quick read.\n",
-      "\n",
-      "---\n",
-      "\n",
-      "### Recommended Improved Prompt\n",
-      "> **Role:** You are a children's story editor. \n",
-      "> **Task:** Summarize the provided text into a single, engaging sentence of no more than 25 words. \n",
-      "> **Tone:** Whimsical and narrative.\n",
-      "> **Constraint:** Ensure you mention the fox’s goal and the ultimate outcome for both the fox and the dog.\n",
-      ">\n",
-      "> **Text:** [Insert Text Here]\n"
-     ]
-    }
-   ],
-   "source": [
-    "critique_prompt = f\"\"\"\n",
-    "You are a prompt engineering expert.\n",
-    "\n",
-    "Here is a prompt:\n",
-    "---\n",
-    "{weak_prompt}\n",
-    "---\n",
-    "\n",
-    "Here is the output it produced:\n",
-    "---\n",
-    "{initial_output}\n",
-    "---\n",
-    "\n",
-    "Critique this prompt. Identify:\n",
-    "1. What is missing from the prompt\n",
-    "2. What is unclear or ambiguous\n",
-    "3. How the output could be improved\n",
-    "\n",
-    "Be specific and concise. Focus on actionable improvements.\n",
-    "\"\"\"\n",
-    "\n",
-    "critique_response = client.models.generate_content(\n",
-    "    model=MODEL_ID,\n",
-    "    contents=critique_prompt\n",
-    ")\n",
-    "\n",
-    "critique = critique_response.text\n",
-    "print(\"Critique:\")\n",
-    "print(critique)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "section4"
-   },
-   "source": [
-    "## Step 4: Have Gemini rewrite the prompt\n",
-    "\n",
-    "Based on the critique, ask Gemini to write a better version of the prompt."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "id": "code4"
-   },
-   "outputs": [
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "qFdPvlXBOdUN"
+      },
+      "source": [
+        "# Gemini API: Self-Improving Prompts"
+      ]
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Improved prompt:\n",
-      "Role: Children's story editor. \n",
-      "Task: Summarize the provided text into a single, engaging sentence of no more than 25 words. \n",
-      "Tone: Whimsical and narrative.\n",
-      "Constraint: Ensure you mention the fox’s goal and the ultimate outcome for both the fox and the dog.\n",
-      "\n",
-      "Text: \n",
-      "The quick brown fox jumps over the lazy dog. The dog was not really lazy, it was just tired from playing all day. The fox was looking for food and saw the dog sleeping. The fox jumped over to get to the other side of the yard where there was a chicken coop. The chickens were scared but the fox did not catch any of them. The farmer heard the noise and came out. The fox ran away. The dog woke up and barked at the fox.\n"
-     ]
-    }
-   ],
-   "source": [
-    "rewrite_prompt = f\"\"\"\n",
-    "Based on the following critique, rewrite the original prompt to produce \n",
-    "a better output.\n",
-    "\n",
-    "Original prompt:\n",
-    "---\n",
-    "{weak_prompt}\n",
-    "---\n",
-    "\n",
-    "Critique:\n",
-    "---\n",
-    "{critique}\n",
-    "---\n",
-    "\n",
-    "Write the improved prompt. Output only the new prompt text, nothing else.\n",
-    "\"\"\"\n",
-    "\n",
-    "rewrite_response = client.models.generate_content(\n",
-    "    model=MODEL_ID,\n",
-    "    contents=rewrite_prompt\n",
-    ")\n",
-    "\n",
-    "improved_prompt = rewrite_response.text\n",
-    "print(\"Improved prompt:\")\n",
-    "print(improved_prompt)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "section5"
-   },
-   "source": [
-    "## Step 5: Run the improved prompt"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "id": "code5"
-   },
-   "outputs": [
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "MfBg1C5NB3X0"
+      },
+      "source": [
+        "<a target=\"_blank\" href=\"https://colab.research.google.com/github/google-gemini/cookbook/blob/main/examples/prompting/Self_Improving_Prompts.ipynb\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" height=30/></a>"
+      ]
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Improved output:\n",
-      "To reach the chickens, the fox vaulted over the dozing dog, but fled empty-pawed once the farmer appeared and the pup woke to bark.\n"
-     ]
-    }
-   ],
-   "source": [
-    "improved_response = client.models.generate_content(\n",
-    "    model=MODEL_ID,\n",
-    "    contents=improved_prompt\n",
-    ")\n",
-    "\n",
-    "improved_output = improved_response.text\n",
-    "print(\"Improved output:\")\n",
-    "print(improved_output)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "section6"
-   },
-   "source": [
-    "## Step 6: Compare before and after"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "id": "code6"
-   },
-   "outputs": [
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "XCVydW40iixa"
+      },
+      "source": [
+        "<table>\n",
+        "  <tr>\n",
+        "    <td style=\"background-color: #d7e6ff;\">\n",
+        "      <a href=\"https://github.com/Karanjot786\" target=\"_blank\" title=\"View profile on GitHub\">\n",
+        "        <img src=\"https://github.com/Karanjot786.png?size=100\"\n",
+        "             alt=\"Karanjot786's GitHub avatar\"\n",
+        "             width=\"100\"\n",
+        "             height=\"100\">\n",
+        "      </a>\n",
+        "    </td>\n",
+        "    <td style=\"background-color: #d7e6ff;\">\n",
+        "      <h2><span style=\"color: black;\">This notebook was contributed by <a href=\"https://github.com/Karanjot786\" target=\"_blank\"><span style=\"color: #217bfe;\"><strong>Karanjot786</strong></span></a>.</span></h2>\n",
+        "      <h5><span style=\"color: black;\">See <a href=\"https://github.com/Karanjot786\" target=\"_blank\"><span style=\"color: #078efb;\"><strong>Karanjot786</strong></span></a> other notebooks <a href=\"https://github.com/search?q=repo%3Agoogle-gemini%2Fcookbook%20%22Karanjot786%22&type=code\" target=\"_blank\"><span style=\"color: #078efb;\">here</span></a>.</h5></span><br>\n",
+        "      <span style=\"color: black;\"><small><em>Have a cool Gemini example? Feel free to <a href=\"https://github.com/google-gemini/cookbook/blob/main/CONTRIBUTING.md\" target=\"_blank\"><span style=\"color: #078efb;\">share it too</span></a>!</em></small></span>\n",
+        "    </td>\n",
+        "  </tr>\n",
+        "</table>"
+      ]
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "==================================================\n",
-      "BEFORE (weak prompt):\n",
-      "A hungry fox jumped over a tired, sleeping dog to reach a chicken coop. However, the fox failed to catch any chickens because the farmer was alerted by the noise and chased him away.\n",
-      "==================================================\n",
-      "AFTER (improved prompt):\n",
-      "To reach the chickens, the fox vaulted over the dozing dog, but fled empty-pawed once the farmer appeared and the pup woke to bark.\n",
-      "==================================================\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(\"=\" * 50)\n",
-    "print(\"BEFORE (weak prompt):\")\n",
-    "print(initial_output)\n",
-    "print(\"=\" * 50)\n",
-    "print(\"AFTER (improved prompt):\")\n",
-    "print(improved_output)\n",
-    "print(\"=\" * 50)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "section7"
-   },
-   "source": [
-    "## Create a reusable function\n",
-    "\n",
-    "Wrap the self-improvement loop into a function you can use with any prompt."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "id": "code7"
-   },
-   "outputs": [],
-   "source": [
-    "def improve_prompt(original_prompt, iterations=2, verbose=True):\n",
-    "    \"\"\"\n",
-    "    Iteratively improve a prompt using Gemini self-critique.\n",
-    "\n",
-    "    Args:\n",
-    "        original_prompt: The initial prompt to improve\n",
-    "        iterations: Number of improvement cycles (default: 2)\n",
-    "        verbose: Print progress (default: True)\n",
-    "\n",
-    "    Returns:\n",
-    "        Tuple of (final_prompt, final_output)\n",
-    "    \"\"\"\n",
-    "    current_prompt = original_prompt\n",
-    "\n",
-    "    for i in range(iterations):\n",
-    "        # Run current prompt\n",
-    "        output = client.models.generate_content(\n",
-    "            model=MODEL_ID,\n",
-    "            contents=current_prompt\n",
-    "        ).text\n",
-    "\n",
-    "        # Critique\n",
-    "        critique = client.models.generate_content(\n",
-    "            model=MODEL_ID,\n",
-    "            contents=f\"\"\"\n",
-    "            Critique this prompt and its output. Be specific and actionable.\n",
-    "\n",
-    "            Prompt:\n",
-    "            {current_prompt}\n",
-    "\n",
-    "            Output:\n",
-    "            {output}\n",
-    "            \"\"\"\n",
-    "        ).text\n",
-    "\n",
-    "        # Rewrite\n",
-    "        current_prompt = client.models.generate_content(\n",
-    "            model=MODEL_ID,\n",
-    "            contents=f\"\"\"\n",
-    "            Rewrite this prompt based on the critique.\n",
-    "            Output only the new prompt text.\n",
-    "\n",
-    "            Original prompt:\n",
-    "            {current_prompt}\n",
-    "\n",
-    "            Critique:\n",
-    "            {critique}\n",
-    "            \"\"\"\n",
-    "        ).text\n",
-    "\n",
-    "        if verbose:\n",
-    "            print(f\"Iteration {i + 1} complete\")\n",
-    "\n",
-    "    # Final run\n",
-    "    final_output = client.models.generate_content(\n",
-    "        model=MODEL_ID,\n",
-    "        contents=current_prompt\n",
-    "    ).text\n",
-    "\n",
-    "    return current_prompt, final_output"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "section8"
-   },
-   "source": [
-    "## Test the function with a new example"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "id": "code8"
-   },
-   "outputs": [
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "xHxb-dlhMIzW"
+      },
+      "source": [
+        "Prompt engineering often involves trial and error. You write a prompt, check the output, then manually tweak the prompt until it works.\n",
+        "\n",
+        "This notebook shows a different approach: let Gemini improve the prompt for you.\n",
+        "\n",
+        "The self-improving prompts pattern works like this:\n",
+        "1. Run an initial prompt\n",
+        "2. Have Gemini critique the output\n",
+        "3. Have Gemini rewrite the prompt based on the critique\n",
+        "4. Run the improved prompt\n",
+        "5. Repeat until satisfied\n",
+        "\n",
+        "This technique is useful when:\n",
+        "- You have a rough idea but need to refine it\n",
+        "- You want to understand what makes a prompt effective\n",
+        "- You need to optimize prompts at scale"
+      ]
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Iteration 1 complete\n",
-      "Iteration 2 complete\n",
-      "\n",
-      "FINAL PROMPT:\n",
-      "Write a Petrarchan sonnet in strict iambic pentameter with a weary, introspective tone about the quiet satisfaction of refactoring a bloated legacy codebase into clean, PEP 8-compliant Python. Avoid clichés like \"dark rooms\" or \"missing semicolons\"; instead, use grounded metaphors of architectural restoration or pruning a wild garden—stripping the scaffolding from brittle functions or thinning out overgrown, deep indentations. Focus on the physical relief of deleting redundant lines and the mental clarity provided by specific Pythonic nuances, such as replacing tangled globals with pure-built functions, the order of clean imports, and the serene breath of a concise docstring.\n",
-      "\n",
-      "FINAL OUTPUT:\n",
-      "I peel the brittle layers from the frame,\n",
-      "Where nested loops once choked the morning light.\n",
-      "This tangled sprawl, a vast and jagged sight,\n",
-      "Had buried every purpose in its name.\n",
-      "I strip the scaffold from the ancient shame\n",
-      "Of global states that rotted in the night;\n",
-      "I prune the deep indent, the thicket’s height,\n",
-      "And bring the wild to heel, precise and tame.\n",
-      "\n",
-      "Now alphabetic imports stand in line\n",
-      "To grant the way to functions’ pure intent.\n",
-      "I purge the bloat, the ghost of errors past;\n",
-      "The docstring, brief, in form so crystalline,\n",
-      "Restores the quiet grace of what was meant.\n",
-      "The screen is light; I am at peace at last.\n"
-     ]
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "monLpKy7423V"
+      },
+      "source": [
+        "## Setup"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "id": "AQJjzmYgH3sX"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Note: you may need to restart the kernel to use updated packages.\n"
+          ]
+        }
+      ],
+      "source": [
+        "%pip install -U -q \"google-genai>=1.0.0\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "85166363b66b"
+      },
+      "source": [
+        "Select the model you want to use:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "id": "6fd823b1bd4e"
+      },
+      "outputs": [],
+      "source": [
+        "MODEL_ID = \"gemini-3-flash-preview\" # @param [\"gemini-2.5-flash-lite\", \"gemini-2.5-flash\", \"gemini-2.5-pro\", \"gemini-3-flash-preview\", \"gemini-3-pro-preview\"] {\"allow-input\":true, isTemplate: true}"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "MUXex9ctTuDB"
+      },
+      "source": [
+        "### Configure your API key\n",
+        "\n",
+        "To run the following cell, your API key must be stored in a Colab Secret named `GOOGLE_API_KEY`. If you don't already have an API key, or you're not sure how to create a Colab Secret, see [Authentication](https://github.com/google-gemini/cookbook/blob/main/quickstarts/Authentication.ipynb) for an example."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "id": "wltbMJLIIXGk"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "from google import genai\n",
+        "\n",
+        "GOOGLE_API_KEY = os.environ.get('GOOGLE_API_KEY')\n",
+        "client = genai.Client(api_key=GOOGLE_API_KEY)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "section1"
+      },
+      "source": [
+        "## Step 1: Start with a weak prompt\n",
+        "\n",
+        "Start with a simple prompt that produces okay results. The goal is to see how much Gemini can improve it."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {
+        "id": "code1"
+      },
+      "outputs": [],
+      "source": [
+        "weak_prompt = \"\"\"\n",
+        "Summarize this text:\n",
+        "\n",
+        "The quick brown fox jumps over the lazy dog. The dog was not really lazy, \n",
+        "it was just tired from playing all day. The fox was looking for food and \n",
+        "saw the dog sleeping. The fox jumped over to get to the other side of the \n",
+        "yard where there was a chicken coop. The chickens were scared but the fox \n",
+        "did not catch any of them. The farmer heard the noise and came out. The \n",
+        "fox ran away. The dog woke up and barked at the fox.\n",
+        "\"\"\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "section2"
+      },
+      "source": [
+        "## Step 2: Run the weak prompt"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {
+        "id": "code2"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Initial output:\n",
+            "A hungry fox jumped over a tired, sleeping dog to reach a chicken coop. However, the farmer heard the commotion and scared the fox away before it could catch any chickens, leaving the dog to wake up and bark at the retreating fox.\n"
+          ]
+        }
+      ],
+      "source": [
+        "initial_response = client.models.generate_content(\n",
+        "    model=MODEL_ID,\n",
+        "    contents=weak_prompt\n",
+        ")\n",
+        "\n",
+        "initial_output = initial_response.text\n",
+        "print(\"Initial output:\")\n",
+        "print(initial_output)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "section3"
+      },
+      "source": [
+        "## Step 3: Have Gemini critique the prompt\n",
+        "\n",
+        "Ask Gemini to analyze what is missing or unclear in the original prompt."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "metadata": {
+        "id": "code3"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Critique:\n",
+            "As a prompt engineering expert, here is my critique of your prompt and its output:\n",
+            "\n",
+            "### 1. What is missing from the prompt\n",
+            "*   **Persona:** No role is assigned (e.g., \"You are a professional editor\" or \"You are a children's storyteller\").\n",
+            "*   **Constraints:** There are no limits on length (word count, sentence count, or character limit).\n",
+            "*   **Format:** The prompt does not specify a structure (e.g., bullet points, a single sentence, or a TL;DR).\n",
+            "*   **Audience:** The target reader is not defined, which affects the tone and vocabulary used.\n",
+            "*   **Delimiters:** The instructions and the source text are not clearly separated using delimiters (like `\"\"\"` or `###`), which can lead to \"instruction injection\" errors in more complex texts.\n",
+            "\n",
+            "### 2. What is unclear or ambiguous\n",
+            "*   **The Goal of the Summary:** Is the purpose to capture the plot, the characters’ motivations, or a \"moral of the story\"?\n",
+            "*   **Depth of Detail:** \"Summarize\" is subjective. It is unclear if the user wants a high-level overview (\"A fox failed to raid a coop\") or a detailed chronological recount.\n",
+            "\n",
+            "### 3. How the output could be improved\n",
+            "While the output is accurate, it could be optimized based on specific needs:\n",
+            "*   **Conciseness:** It includes \"fluff\" adjectives (e.g., \"tired, sleeping\") that may not be necessary for a strict summary.\n",
+            "*   **Readability:** For a quick scan, a bulleted list would be more effective than a dense paragraph.\n",
+            "*   **Focus:** The output treats the dog and the fox with equal weight, whereas a summary focused on the *conflict* might ignore the dog’s backstory entirely to save space.\n",
+            "\n",
+            "---\n",
+            "\n",
+            "### Improved Prompt Example\n",
+            "> **Role:** You are a concise copy editor.\n",
+            "> **Task:** Summarize the text delimited by triple quotes into **two bullet points**.\n",
+            "> **Constraint:** Focus only on the primary action and the outcome. Keep the total word count under 20 words.\n",
+            "> **Text:** \n",
+            "> \"\"\"\n",
+            "> [Insert Text Here]\n",
+            "> \"\"\"\n"
+          ]
+        }
+      ],
+      "source": [
+        "critique_prompt = f\"\"\"\n",
+        "You are a prompt engineering expert.\n",
+        "\n",
+        "Here is a prompt:\n",
+        "---\n",
+        "{weak_prompt}\n",
+        "---\n",
+        "\n",
+        "Here is the output it produced:\n",
+        "---\n",
+        "{initial_output}\n",
+        "---\n",
+        "\n",
+        "Critique this prompt. Identify:\n",
+        "1. What is missing from the prompt\n",
+        "2. What is unclear or ambiguous\n",
+        "3. How the output could be improved\n",
+        "\n",
+        "Be specific and concise. Focus on actionable improvements.\n",
+        "\"\"\"\n",
+        "\n",
+        "critique_response = client.models.generate_content(\n",
+        "    model=MODEL_ID,\n",
+        "    contents=critique_prompt\n",
+        ")\n",
+        "\n",
+        "critique = critique_response.text\n",
+        "print(\"Critique:\")\n",
+        "print(critique)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "section4"
+      },
+      "source": [
+        "## Step 4: Have Gemini rewrite the prompt\n",
+        "\n",
+        "Based on the critique, ask Gemini to write a better version of the prompt."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {
+        "id": "code4"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Improved prompt:\n",
+            "As a professional copy editor, summarize the text delimited by triple quotes into two concise bullet points. Focus specifically on the primary action and the final outcome, keeping the total word count under 25 words.\n",
+            "\n",
+            "Text:\n",
+            "\"\"\"\n",
+            "The quick brown fox jumps over the lazy dog. The dog was not really lazy, it was just tired from playing all day. The fox was looking for food and saw the dog sleeping. The fox jumped over to get to the other side of the yard where there was a chicken coop. The chickens were scared but the fox did not catch any of them. The farmer heard the noise and came out. The fox ran away. The dog woke up and barked at the fox.\n",
+            "\"\"\"\n"
+          ]
+        }
+      ],
+      "source": [
+        "rewrite_prompt = f\"\"\"\n",
+        "Based on the following critique, rewrite the original prompt to produce \n",
+        "a better output.\n",
+        "\n",
+        "Original prompt:\n",
+        "---\n",
+        "{weak_prompt}\n",
+        "---\n",
+        "\n",
+        "Critique:\n",
+        "---\n",
+        "{critique}\n",
+        "---\n",
+        "\n",
+        "Write the improved prompt. Output only the new prompt text, nothing else.\n",
+        "\"\"\"\n",
+        "\n",
+        "rewrite_response = client.models.generate_content(\n",
+        "    model=MODEL_ID,\n",
+        "    contents=rewrite_prompt\n",
+        ")\n",
+        "\n",
+        "improved_prompt = rewrite_response.text\n",
+        "print(\"Improved prompt:\")\n",
+        "print(improved_prompt)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "section5"
+      },
+      "source": [
+        "## Step 5: Run the improved prompt"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "id": "code5"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Improved output:\n",
+            "* Fox jumps a sleeping dog to raid chickens.\n",
+            "* The fox flees empty-handed after being discovered.\n"
+          ]
+        }
+      ],
+      "source": [
+        "improved_response = client.models.generate_content(\n",
+        "    model=MODEL_ID,\n",
+        "    contents=improved_prompt\n",
+        ")\n",
+        "\n",
+        "improved_output = improved_response.text\n",
+        "print(\"Improved output:\")\n",
+        "print(improved_output)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "section6"
+      },
+      "source": [
+        "## Step 6: Compare before and after"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {
+        "id": "code6"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "==================================================\n",
+            "BEFORE (weak prompt):\n",
+            "A hungry fox jumped over a tired, sleeping dog to reach a chicken coop. However, the farmer heard the commotion and scared the fox away before it could catch any chickens, leaving the dog to wake up and bark at the retreating fox.\n",
+            "==================================================\n",
+            "AFTER (improved prompt):\n",
+            "* Fox jumps a sleeping dog to raid chickens.\n",
+            "* The fox flees empty-handed after being discovered.\n",
+            "==================================================\n"
+          ]
+        }
+      ],
+      "source": [
+        "print(\"=\" * 50)\n",
+        "print(\"BEFORE (weak prompt):\")\n",
+        "print(initial_output)\n",
+        "print(\"=\" * 50)\n",
+        "print(\"AFTER (improved prompt):\")\n",
+        "print(improved_output)\n",
+        "print(\"=\" * 50)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "section7"
+      },
+      "source": [
+        "## Create a reusable function\n",
+        "\n",
+        "Wrap the self-improvement loop into a function you can use with any prompt."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "metadata": {
+        "id": "code7"
+      },
+      "outputs": [],
+      "source": [
+        "# @title Define improve_prompt function\n",
+        "def improve_prompt(original_prompt, iterations=2, verbose=True):\n",
+        "    \"\"\"\n",
+        "    Iteratively improve a prompt using Gemini self-critique.\n",
+        "\n",
+        "    Args:\n",
+        "        original_prompt: The initial prompt to improve\n",
+        "        iterations: Number of improvement cycles (default: 2)\n",
+        "        verbose: Print progress (default: True)\n",
+        "\n",
+        "    Returns:\n",
+        "        Tuple of (final_prompt, final_output)\n",
+        "    \"\"\"\n",
+        "    current_prompt = original_prompt\n",
+        "\n",
+        "    for i in range(iterations):\n",
+        "        # Run current prompt\n",
+        "        output = client.models.generate_content(\n",
+        "            model=MODEL_ID,\n",
+        "            contents=current_prompt\n",
+        "        ).text\n",
+        "\n",
+        "        # Critique\n",
+        "        critique = client.models.generate_content(\n",
+        "            model=MODEL_ID,\n",
+        "            contents=f\"\"\"\n",
+        "            Critique this prompt and its output. Be specific and actionable.\n",
+        "\n",
+        "            Prompt:\n",
+        "            {current_prompt}\n",
+        "\n",
+        "            Output:\n",
+        "            {output}\n",
+        "            \"\"\"\n",
+        "        ).text\n",
+        "\n",
+        "        # Rewrite\n",
+        "        current_prompt = client.models.generate_content(\n",
+        "            model=MODEL_ID,\n",
+        "            contents=f\"\"\"\n",
+        "            Rewrite this prompt based on the critique.\n",
+        "            Output only the new prompt text.\n",
+        "\n",
+        "            Original prompt:\n",
+        "            {current_prompt}\n",
+        "\n",
+        "            Critique:\n",
+        "            {critique}\n",
+        "            \"\"\"\n",
+        "        ).text\n",
+        "\n",
+        "        if verbose:\n",
+        "            print(f\"Iteration {i + 1} complete\")\n",
+        "\n",
+        "    # Final run\n",
+        "    final_output = client.models.generate_content(\n",
+        "        model=MODEL_ID,\n",
+        "        contents=current_prompt\n",
+        "    ).text\n",
+        "\n",
+        "    return current_prompt, final_output"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "section8"
+      },
+      "source": [
+        "## Test the function with a new example"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "metadata": {
+        "id": "code8"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Iteration 1 complete\n",
+            "Iteration 2 complete\n",
+            "\n",
+            "FINAL PROMPT:\n",
+            "Write a three-stanza noir-detective poem about a Heisenbug. Focus specifically on the Observer Effect—how the act of debugging or probing the system alters its state and causes the error to vanish. Avoid noir clichés like \"driving rain,\" \"trench coats,\" or \"pouring coffee.\" Instead of using \"zeros and ones,\" \"binary,\" or \"logic,\" ground the imagery in hardware-level metaphors involving silicon, voltage, memory addresses, concurrency, or hardware clock cycles.\n",
+            "\n",
+            "FINAL OUTPUT:\n",
+            "The suspect left a shadow across the silicon grid, a smear of stray current at a locked address. I crouched in the quiet of the L3 cache, watching the clock cycles pulse like a heavy, metronomic heartbeat. It was a race condition, a ghost pacing the bus, waiting for a collision that never happened twice in the same light. I traced the cold geometry of the traces, looking for where the voltage bled into the substrate, leaving a trail of corrupted parity that didn't belong to any known process.\n",
+            "\n",
+            "I clicked the probe into place, a heavy intrusion into a delicate circuit. The moment the copper tip kissed the pin, the landscape shifted; my very presence sucked the stray capacitance right out of the room. The gate that had been stuck wide open slammed shut, spooked by the impedance of my own curiosity. I was no longer a witness—I was the interference, a clumsy giant stepping through a house of glass, altering the very physics of the crime I was sent to solve.\n",
+            "\n",
+            "The log went flat, a clean slate where the carnage used to be. Every bit had realigned, scrubbed by the pulse of my inquiry, leaving nothing but the thermal hum and a perfectly timed refresh cycle. I stood alone in the quiet of the die, staring at a memory map that swore on its life it was innocent. The bug wasn’t dead; it had just slipped into the jitter, moving to a neighborhood where the light of an oscilloscope never reaches.\n"
+          ]
+        }
+      ],
+      "source": [
+        "test_prompt = \"Write a poem about coding.\"\n",
+        "\n",
+        "final_prompt, final_output = improve_prompt(test_prompt, iterations=2)\n",
+        "\n",
+        "print(\"\\nFINAL PROMPT:\")\n",
+        "print(final_prompt)\n",
+        "print(\"\\nFINAL OUTPUT:\")\n",
+        "print(final_output)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "nextsteps"
+      },
+      "source": [
+        "## Next steps\n",
+        "\n",
+        "### Related notebooks\n",
+        "\n",
+        "- [Chain of thought prompting](./Chain_of_thought_prompting.ipynb)\n",
+        "- [Self-ask prompting](./Self_ask_prompting.ipynb)\n",
+        "- [Few-shot prompting](./Few_shot_prompting.ipynb)\n",
+        "\n",
+        "### Ideas to extend this pattern\n",
+        "\n",
+        "- Add a scoring function to measure improvement\n",
+        "- Use multiple Gemini models (one for critique, one for rewriting)\n",
+        "- Store improvement history for analysis\n",
+        "- Combine with few-shot examples for domain-specific optimization"
+      ]
     }
-   ],
-   "source": [
-    "test_prompt = \"Write a poem about coding.\"\n",
-    "\n",
-    "final_prompt, final_output = improve_prompt(test_prompt, iterations=2)\n",
-    "\n",
-    "print(\"\\nFINAL PROMPT:\")\n",
-    "print(final_prompt)\n",
-    "print(\"\\nFINAL OUTPUT:\")\n",
-    "print(final_output)"
-   ]
+  ],
+  "metadata": {
+    "colab": {
+      "collapsed_sections": [
+        "Tce3stUlHN0L"
+      ],
+      "name": "Self_Improving_Prompts.ipynb",
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "nextsteps"
-   },
-   "source": [
-    "## Next steps\n",
-    "\n",
-    "### Related notebooks\n",
-    "\n",
-    "- [Chain of thought prompting](./Chain_of_thought_prompting.ipynb)\n",
-    "- [Self-ask prompting](./Self_ask_prompting.ipynb)\n",
-    "- [Few-shot prompting](./Few_shot_prompting.ipynb)\n",
-    "\n",
-    "### Ideas to extend this pattern\n",
-    "\n",
-    "- Add a scoring function to measure improvement\n",
-    "- Use multiple Gemini models (one for critique, one for rewriting)\n",
-    "- Store improvement history for analysis\n",
-    "- Combine with few-shot examples for domain-specific optimization"
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "collapsed_sections": [
-    "Tce3stUlHN0L"
-   ],
-   "name": "Self_Improving_Prompts.ipynb",
-   "toc_visible": true
-  },
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.14.2"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/examples/prompting/Self_Improving_Prompts.ipynb
+++ b/examples/prompting/Self_Improving_Prompts.ipynb
@@ -164,10 +164,10 @@
       },
       "outputs": [],
       "source": [
-        "import os\n",
+        "from google.colab import userdata\n",
         "from google import genai\n",
         "\n",
-        "GOOGLE_API_KEY = os.environ.get('GOOGLE_API_KEY')\n",
+        "GOOGLE_API_KEY = userdata.get('GOOGLE_API_KEY')\n",
         "client = genai.Client(api_key=GOOGLE_API_KEY)"
       ]
     },


### PR DESCRIPTION
Closes #1110

## What this PR does

Adds a new prompting example showing how to use Gemini to optimize prompts through self-critique.

## Changes

- New notebook: `examples/prompting/Self_Improving_Prompts.ipynb`
- Updated [examples/prompting/README.md](cci:7://file:///Users/ksd/Desktop/OSCs/gsoc-2026/google-deepmind/cookbook/examples/prompting/README.md:0:0-0:0) with new entry

## Notebook contents

1. Start with a weak prompt
2. Run the prompt and get output
3. Have Gemini critique the prompt
4. Have Gemini rewrite the prompt based on critique
5. Run the improved prompt
6. Compare before and after results
7. Reusable `improve_prompt()` function for any prompt

## Example output

Before: Generic 2-sentence summary
After: Single sentence, 25 words, specific tone and constraints

The `improve_prompt()` function took "Write a poem about coding" and after 2 iterations produced a full Petrarchan sonnet about refactoring code.

## Testing

- Ran all cells in Colab
- Verified outputs show clear improvement
- Formatted with nbfmt
- Linted with nblint

cc @Giom-V @patrickloeber