### PR TITLE
Fix unused os import in quickstarts/Get_started_LiveAPI.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 **/.python-version
 **/desktop.ini
 **.lnk
+**/.env
 
 # Ignore fork-syncing workflow, should only exist in forks
 # cf. https://github.com/Giom-V/gemini-api-cookbook/blob/main/.github/workflows/sync.yml

--- a/quickstarts/Get_started_LiveAPI.py
+++ b/quickstarts/Get_started_LiveAPI.py
@@ -82,7 +82,8 @@ api_key = os.environ.get("GOOGLE_API_KEY")
 if api_key is None:
     print("Please set the GOOGLE_API_KEY environment variable.")
     print("You can get an API key from https://aistudio.google.com/app/apikey")
-    api_key = input("Or enter your API key here: ").strip()
+    while not api_key:
+        api_key = input("Or enter your API key here: ").strip()
 
 client = genai.Client(api_key=api_key, http_options={"api_version": "v1beta"})
 

--- a/quickstarts/Get_started_LiveAPI.py
+++ b/quickstarts/Get_started_LiveAPI.py
@@ -77,7 +77,14 @@ MODEL = "gemini-2.5-flash-native-audio-preview-12-2025"
 
 DEFAULT_MODE = "camera"
 
-client = genai.Client(http_options={"api_version": "v1beta"})
+api_key = os.environ.get("GOOGLE_API_KEY")
+
+if api_key is None:
+    print("Please set the GOOGLE_API_KEY environment variable.")
+    print("You can get an API key from https://aistudio.google.com/app/apikey")
+    api_key = input("Or enter your API key here: ").strip()
+
+client = genai.Client(api_key=api_key, http_options={"api_version": "v1beta"})
 
 CONFIG = {"response_modalities": ["AUDIO"]}
 


### PR DESCRIPTION
Problem: 
The os module was imported but never used in the script. The genai.Client() was relying on implicit environment variable detection, which:

1.  Makes the code less readable/explicit
2.  Doesn't provide helpful error messages if the API key is missing
3.  Is inconsistent with other quickstarts like Get_started_LyriaRealTime.py