### PR TITLE
Fix Live API video streaming in Get_started_LiveAPI quickstart

### DIFF
--- a/quickstarts/Get_started_LiveAPI.py
+++ b/quickstarts/Get_started_LiveAPI.py
@@ -91,12 +91,21 @@ CONFIG = types.LiveConnectConfig(
     response_modalities=["AUDIO"],
     speech_config=types.SpeechConfig(
         voice_config=types.VoiceConfig(
-            prebuilt_voice_config=types.PrebuiltVoiceConfig(voice_name = "Zephyr")
+            prebuilt_voice_config=types.PrebuiltVoiceConfig(voice_name="Zephyr")
         )
     ),
+    realtime_input_config=types.RealtimeInputConfig(
+        activity_handling=types.ActivityHandling.NO_INTERRUPTION,
+        automatic_activity_detection=types.AutomaticActivityDetection(
+            start_of_speech_sensitivity=types.StartSensitivity.START_SENSITIVITY_HIGH,
+            end_of_speech_sensitivity=types.EndSensitivity.END_SENSITIVITY_HIGH,
+            silence_duration_ms=800,
+            prefix_padding_ms=300,
+        ),
+    ),
     context_window_compression=types.ContextWindowCompressionConfig(
-        trigger_tokens = 25600,
-        sliding_window = types.SlidingWindow(target_tokens=12800),
+        trigger_tokens=25600,
+        sliding_window=types.SlidingWindow(target_tokens=12800),
     ),
 )
 
@@ -238,10 +247,11 @@ class AudioVideoLoop:
     def _capture_screen(self):
         sct = mss.mss()
         monitor = sct.monitors[0]
-        
+
         i = sct.grab(monitor)
-        
+
         img = PIL.Image.frombytes("RGB", i.size, i.rgb)
+        img.thumbnail([1024, 1024])
 
         image_io = io.BytesIO()
         img.save(image_io, format="jpeg")
@@ -289,7 +299,7 @@ class AudioVideoLoop:
                 if msg["mime_type"].startswith("audio/"):
                     await self.session.send_realtime_input(audio=msg)
                 else:
-                    await self.session.send_realtime_input(media=msg)
+                    await self.session.send_realtime_input(video=msg)
         except asyncio.CancelledError:
             pass
 


### PR DESCRIPTION
## Summary

This updates `quickstarts/Get_started_LiveAPI.py` to use the explicit Live API video realtime input path and adds a more forgiving realtime activity configuration for mixed audio/video sessions.

## Changes

- send image frames with `session.send_realtime_input(video=msg)` instead of `media=msg`
- configure `realtime_input_config` with:
  - `activity_handling=NO_INTERRUPTION`
  - higher speech sensitivity
  - `silence_duration_ms=800`
  - `prefix_padding_ms=300`
- resize screen captures to `1024x1024` before JPEG encoding

## Why

Issue #1108 reports that the quickstart can hallucinate visual content and fail to describe the shared screen or camera feed correctly. The current Live API docs describe explicit realtime `video` input fields, and this patch aligns the sample with that API shape while also giving the session more time to process multimodal input before responding.

## Verification

- `python -m py_compile quickstarts/Get_started_LiveAPI.py`


