### PR TITLE
fix: align error handling notebook with google-genai retries

### DIFF
--- a/quickstarts/Error_handling.ipynb
+++ b/quickstarts/Error_handling.ipynb
@@ -117,7 +117,7 @@
       "source": [
         "### Automatic retries\n",
         "\n",
-        "The Gemini API's client library offers built-in retry mechanisms for handling transient errors. You can enable this feature by using the `request_options` argument with API calls like `generate_content`, `generate_answer`, `embed_content`, and `generate_content_async`.\n",
+        "When using `google-genai`, you can configure retries through `HttpRetryOptions` in `google.genai.types`. This keeps the retry behavior aligned with the exceptions the SDK actually raises.\n",
         "\n",
         "**Advantages:**\n",
         "\n",
@@ -126,13 +126,12 @@
         "\n",
         "**Customize retry behavior:**\n",
         "\n",
-        "Use these settings in [`retry`](https://googleapis.dev/python/google-api-core/latest/retry.html) to customize retry behavior:\n",
+        "Use `HttpRetryOptions` to control retry attempts, delays, and which HTTP status codes should be retried.\n",
         "\n",
-        "* `predicate`:  (callable) Determines if an exception is retryable. Default: [`if_transient_error`](https://github.com/googleapis/python-api-core/blob/main/google/api_core/retry/retry_base.py#L75C4-L75C13)\n",
-        "* `initial`: (float) Initial delay in seconds before the first retry. Default: `1.0`\n",
-        "* `maximum`: (float) Maximum delay in seconds between retries. Default: `60.0`\n",
-        "* `multiplier`: (float) Factor by which the delay increases after each retry. Default: `2.0`\n",
-        "* `timeout`: (float) Total retry duration in seconds. Default: `120.0`"
+        "* `attempts`: Total number of attempts before giving up.\n",
+        "* `initial_delay`: Initial delay in seconds before the first retry.\n",
+        "* `max_delay`: Maximum delay in seconds between retries.\n",
+        "* `http_status_codes`: HTTP status codes that should trigger a retry."
       ]
     },
     {
@@ -157,23 +156,26 @@
         }
       ],
       "source": [
-        "from google.api_core import retry\n",
+        "from google.genai import types\n",
         "\n",
         "MODEL_ID = \"gemini-3.5-flash\" # @param [\"gemini-2.5-flash\", \"gemini-2.5-pro\", \"gemini-2.5-flash-preview\", \"gemini-3.1-flash-lite\", \"gemini-3.1-pro-preview\"] {\"allow-input\":true, isTemplate: true}\n",
         "\n",
         "prompt = \"Write a story about a magic backpack.\"\n",
         "\n",
-        "#Built in retry support was removed from the sdk, so you need to use retry package\n",
-        "@retry.Retry(\n",
-        "    predicate=retry.if_transient_error,\n",
+        "retry_options = types.HttpRetryOptions(\n",
+        "    attempts=5,\n",
+        "    initial_delay=2.0,\n",
+        "    max_delay=30.0,\n",
+        "    http_status_codes=[408, 429, 500, 502, 503, 504],\n",
         ")\n",
-        "def generate_with_retry():\n",
-        "  return client.models.generate_content(\n",
-        "      model=MODEL_ID,\n",
-        "      contents=prompt\n",
-        "  )\n",
         "\n",
-        "generate_with_retry().text"
+        "client.models.generate_content(\n",
+        "    model=MODEL_ID,\n",
+        "    contents=prompt,\n",
+        "    config=types.GenerateContentConfig(\n",
+        "        http_options=types.HttpOptions(retry_options=retry_options)\n",
+        "    )\n",
+        ").text"
       ]
     },
     {
@@ -184,7 +186,7 @@
       "source": [
         "### Manually increase timeout when responses take time\n",
         "\n",
-        "If you encounter `ReadTimeout` or `DeadlineExceeded` errors, meaning an API call exceeds the default timeout (600 seconds), you can manually adjust it by defining `timeout` in the `request_options` argument."
+        "If you encounter `ReadTimeout` or `DeadlineExceeded` errors, meaning an API call exceeds the default timeout (600 seconds), you can manually adjust it by defining `timeout` in the `http_options` argument."
       ]
     },
     {
@@ -259,12 +261,16 @@
         }
       ],
       "source": [
-        "from google.api_core import retry, exceptions\n",
+        "from google.api_core import retry\n",
+        "from google.genai import errors\n",
         "\n",
         "MODEL_ID = \"gemini-3.5-flash\" # @param [\"gemini-2.5-flash\", \"gemini-2.5-pro\", \"gemini-2.5-flash-preview\", \"gemini-3.1-flash-lite\", \"gemini-3.1-pro-preview\"] {\"allow-input\":true, isTemplate: true}\n",
         "\n",
+        "def if_genai_transient_error(exception):\n",
+        "    return isinstance(exception, errors.APIError) and exception.code in {408, 429, 500, 502, 503, 504}\n",
+        "\n",
         "@retry.Retry(\n",
-        "    predicate=retry.if_transient_error,\n",
+        "    predicate=if_genai_transient_error,\n",
         "    initial=2.0,\n",
         "    maximum=64.0,\n",
         "    multiplier=2.0,\n",
@@ -290,7 +296,7 @@
       "source": [
         "### Test the error handling with retry mechanism\n",
         "\n",
-        "To validate that your error handling and retry mechanism work as intended, define a `generate_content` function that deliberately raises a `ServiceUnavailable` error on the first call. This setup will help you ensure that the retry decorator successfully handles the transient error and retries the operation."
+        "To validate that your retry mechanism works as intended, define a `generate_content` function that deliberately raises a `google.genai.errors.ServerError` on the first call. This mirrors the exception family used by `google-genai` for transient server-side failures."
       ]
     },
     {
@@ -322,11 +328,15 @@
         }
       ],
       "source": [
-        "from google.api_core import retry, exceptions\n",
+        "from google.api_core import retry\n",
+        "from google.genai import errors\n",
+        "\n",
+        "def if_genai_transient_error(exception):\n",
+        "    return isinstance(exception, errors.APIError) and exception.code in {408, 429, 500, 502, 503, 504}\n",
         "\n",
         "\n",
         "@retry.Retry(\n",
-        "    predicate=retry.if_transient_error,\n",
+        "    predicate=if_genai_transient_error,\n",
         "    initial=2.0,\n",
         "    maximum=64.0,\n",
         "    multiplier=2.0,\n",
@@ -340,14 +350,18 @@
         "\n",
         "    try:\n",
         "        if generate_content_first_fail.call_counter == 1:\n",
-        "            raise exceptions.ServiceUnavailable(\"Service Unavailable\")\n",
+        "            raise errors.ServerError(\n",
+        "                503,\n",
+        "                {\"error\": {\"code\": 503, \"message\": \"Service Unavailable\", \"status\": \"UNAVAILABLE\"}},\n",
+        "                None,\n",
+        "            )\n",
         "\n",
         "        response = client.models.generate_content(\n",
         "            model=MODEL_ID,\n",
         "            contents=prompt\n",
         "        )\n",
         "        return response.text\n",
-        "    except exceptions.ServiceUnavailable as e:\n",
+        "    except errors.ServerError as e:\n",
         "        print(f\"Error: {e}\")\n",
         "        raise\n",
         "\n",

--- a/quickstarts/Error_handling.ipynb
+++ b/quickstarts/Error_handling.ipynb
@@ -117,7 +117,7 @@
       "source": [
         "### Automatic retries\n",
         "\n",
-        "The Gemini API's client library offers built-in retry mechanisms for handling transient errors. You can enable this feature by using the `request_options` argument with API calls like `generate_content`, `generate_answer`, `embed_content`, and `generate_content_async`.\n",
+        "When using `google-genai`, you can configure retries through `HttpRetryOptions` in `google.genai.types`. This keeps the retry behavior aligned with the exceptions the SDK actually raises.\n",
         "\n",
         "**Advantages:**\n",
         "\n",
@@ -126,13 +126,12 @@
         "\n",
         "**Customize retry behavior:**\n",
         "\n",
-        "Use these settings in [`retry`](https://googleapis.dev/python/google-api-core/latest/retry.html) to customize retry behavior:\n",
+        "Use `HttpRetryOptions` to control retry attempts, delays, and which HTTP status codes should be retried.\n",
         "\n",
-        "* `predicate`:  (callable) Determines if an exception is retryable. Default: [`if_transient_error`](https://github.com/googleapis/python-api-core/blob/main/google/api_core/retry/retry_base.py#L75C4-L75C13)\n",
-        "* `initial`: (float) Initial delay in seconds before the first retry. Default: `1.0`\n",
-        "* `maximum`: (float) Maximum delay in seconds between retries. Default: `60.0`\n",
-        "* `multiplier`: (float) Factor by which the delay increases after each retry. Default: `2.0`\n",
-        "* `timeout`: (float) Total retry duration in seconds. Default: `120.0`"
+        "* `attempts`: Total number of attempts before giving up.\n",
+        "* `initial_delay`: Initial delay in seconds before the first retry.\n",
+        "* `max_delay`: Maximum delay in seconds between retries.\n",
+        "* `http_status_codes`: HTTP status codes that should trigger a retry."
       ]
     },
     {
@@ -157,23 +156,26 @@
         }
       ],
       "source": [
-        "from google.api_core import retry\n",
+        "from google.genai import types\n",
         "\n",
-        "MODEL_ID = \"gemini-3-flash-preview\" # @param [\"gemini-2.5-flash\", \"gemini-2.5-pro\", \"gemini-2.5-flash-preview\", \"gemini-3.1-flash-lite\", \"gemini-3.1-pro-preview\"] {\"allow-input\":true, isTemplate: true}\n",
+        "MODEL_ID = \"gemini-3-flash-preview\" # @param [\"gemini-2.5-flash\", \"gemini-2.5-pro\", \"gemini-2.5-flash-preview\", \"gemini-3-flash-preview\", \"gemini-3.1-flash-lite\", \"gemini-3.1-pro-preview\"] {\"allow-input\":true, isTemplate: true}\n",
         "\n",
         "prompt = \"Write a story about a magic backpack.\"\n",
         "\n",
-        "#Built in retry support was removed from the sdk, so you need to use retry package\n",
-        "@retry.Retry(\n",
-        "    predicate=retry.if_transient_error,\n",
+        "retry_options = types.HttpRetryOptions(\n",
+        "    attempts=5,\n",
+        "    initial_delay=2.0,\n",
+        "    max_delay=30.0,\n",
+        "    http_status_codes=[408, 429, 500, 502, 503, 504],\n",
         ")\n",
-        "def generate_with_retry():\n",
-        "  return client.models.generate_content(\n",
-        "      model=MODEL_ID,\n",
-        "      contents=prompt\n",
-        "  )\n",
         "\n",
-        "generate_with_retry().text"
+        "client.models.generate_content(\n",
+        "    model=MODEL_ID,\n",
+        "    contents=prompt,\n",
+        "    config=types.GenerateContentConfig(\n",
+        "        http_options=types.HttpOptions(retry_options=retry_options)\n",
+        "    )\n",
+        ").text"
       ]
     },
     {
@@ -184,7 +186,7 @@
       "source": [
         "### Manually increase timeout when responses take time\n",
         "\n",
-        "If you encounter `ReadTimeout` or `DeadlineExceeded` errors, meaning an API call exceeds the default timeout (600 seconds), you can manually adjust it by defining `timeout` in the `request_options` argument."
+        "If you encounter `ReadTimeout` or `DeadlineExceeded` errors, meaning an API call exceeds the default timeout (600 seconds), you can manually adjust it by defining `timeout` in the `http_options` argument."
       ]
     },
     {
@@ -259,12 +261,16 @@
         }
       ],
       "source": [
-        "from google.api_core import retry, exceptions\n",
+        "from google.api_core import retry\n",
+        "from google.genai import errors\n",
         "\n",
-        "MODEL_ID = \"gemini-3-flash-preview\" # @param [\"gemini-2.5-flash\", \"gemini-2.5-pro\", \"gemini-2.5-flash-preview\", \"gemini-3.1-flash-lite\", \"gemini-3.1-pro-preview\"] {\"allow-input\":true, isTemplate: true}\n",
+        "MODEL_ID = \"gemini-3-flash-preview\" # @param [\"gemini-2.5-flash\", \"gemini-2.5-pro\", \"gemini-2.5-flash-preview\", \"gemini-3-flash-preview\", \"gemini-3.1-flash-lite\", \"gemini-3.1-pro-preview\"] {\"allow-input\":true, isTemplate: true}\n",
+        "\n",
+        "def if_genai_transient_error(exception):\n",
+        "    return isinstance(exception, errors.APIError) and exception.code in {408, 429, 500, 502, 503, 504}\n",
         "\n",
         "@retry.Retry(\n",
-        "    predicate=retry.if_transient_error,\n",
+        "    predicate=if_genai_transient_error,\n",
         "    initial=2.0,\n",
         "    maximum=64.0,\n",
         "    multiplier=2.0,\n",
@@ -290,7 +296,7 @@
       "source": [
         "### Test the error handling with retry mechanism\n",
         "\n",
-        "To validate that your error handling and retry mechanism work as intended, define a `generate_content` function that deliberately raises a `ServiceUnavailable` error on the first call. This setup will help you ensure that the retry decorator successfully handles the transient error and retries the operation."
+        "To validate that your retry mechanism works as intended, define a `generate_content` function that deliberately raises a `google.genai.errors.ServerError` on the first call. This mirrors the exception family used by `google-genai` for transient server-side failures."
       ]
     },
     {
@@ -322,11 +328,15 @@
         }
       ],
       "source": [
-        "from google.api_core import retry, exceptions\n",
+        "from google.api_core import retry\n",
+        "from google.genai import errors\n",
+        "\n",
+        "def if_genai_transient_error(exception):\n",
+        "    return isinstance(exception, errors.APIError) and exception.code in {408, 429, 500, 502, 503, 504}\n",
         "\n",
         "\n",
         "@retry.Retry(\n",
-        "    predicate=retry.if_transient_error,\n",
+        "    predicate=if_genai_transient_error,\n",
         "    initial=2.0,\n",
         "    maximum=64.0,\n",
         "    multiplier=2.0,\n",
@@ -340,14 +350,18 @@
         "\n",
         "    try:\n",
         "        if generate_content_first_fail.call_counter == 1:\n",
-        "            raise exceptions.ServiceUnavailable(\"Service Unavailable\")\n",
+        "            raise errors.ServerError(\n",
+        "                503,\n",
+        "                {\"error\": {\"code\": 503, \"message\": \"Service Unavailable\", \"status\": \"UNAVAILABLE\"}},\n",
+        "                None,\n",
+        "            )\n",
         "\n",
         "        response = client.models.generate_content(\n",
         "            model=MODEL_ID,\n",
         "            contents=prompt\n",
         "        )\n",
         "        return response.text\n",
-        "    except exceptions.ServiceUnavailable as e:\n",
+        "    except errors.ServerError as e:\n",
         "        print(f\"Error: {e}\")\n",
         "        raise\n",
         "\n",


### PR DESCRIPTION
## Summary

This PR updates `quickstarts/Error_handling.ipynb` so the retry guidance and examples match the exceptions raised by `google-genai`.

## What changed

- updated the automatic retry section to use `google.genai.types.HttpRetryOptions`
- updated the manual retry example to use a custom predicate for `google.genai.errors.APIError`
- updated the retry test example to raise and catch `google.genai.errors.ServerError` instead of `google.api_core.exceptions.ServiceUnavailable`

## Why

Issue #1091 points out that the current notebook demonstrates retry behavior using `google.api_core.exceptions`, while real `google-genai` requests raise exceptions from `google.genai.errors`.

As written, the notebook can give readers a retry pattern that does not match the SDK's actual exception model. This change makes the examples consistent with the behavior users will see in production.

## Notes

- notebook-only change
- no runtime package changes

Closes #1091
