### PR TITLE
Fix scale= command in Lyria realtime quickstart

### DIFF
--- a/quickstarts/Get_started_LyriaRealTime.py
+++ b/quickstarts/Get_started_LyriaRealTime.py
@@ -130,9 +130,10 @@ async def main():
                     del config.scale
                     print(f"Setting Scale to AUTO, which requires resetting context.")
                   else:
+                    scale_name = prompt_str.removeprefix('scale=').strip()
                     found_scale_enum_member = None
                     for scale_member in types.Scale: # types.Scale is an enum
-                        if scale_member.name.lower() == prompt_str.lower():
+                        if scale_member.name.lower() == scale_name.lower():
                             found_scale_enum_member = scale_member
                             break
                     if found_scale_enum_member:


### PR DESCRIPTION
## Bug

In `quickstarts/Get_started_LyriaRealTime.py`, the `scale=` command parser compares the raw `prompt_str` (which still contains the `scale=` prefix, e.g. `scale=A_FLAT_MAJOR_F_MINOR`) against `types.Scale` enum names (e.g. `A_FLAT_MAJOR_F_MINOR`). The equality check never succeeds and the command always falls through to `Error: Matching enum not found.`, making the `scale=` command effectively non-functional.

## Fix

Strip the `scale=` prefix (and whitespace) before comparing, mirroring how the sibling `bpm=` (L121) and `top_k=` (L148) handlers already work.

## Repro

```
> scale=A_FLAT_MAJOR_F_MINOR
Error: Matching enum not found.
```

After the fix:
```
> scale=A_FLAT_MAJOR_F_MINOR
Setting scale to A_FLAT_MAJOR_F_MINOR, which requires resetting context.
```