### PR TITLE
fix: remove leftover google-generativeai imports from two notebooks

### DIFF
--- a/examples/Animated_Story_Video_Generation_gemini.ipynb
+++ b/examples/Animated_Story_Video_Generation_gemini.ipynb
@@ -86,17 +86,6 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "iQSKjF5WH5N9"
-      },
-      "outputs": [],
-      "source": [
-        "import google.generativeai as genai"
-      ]
-    },
-    {
       "cell_type": "markdown",
       "metadata": {
         "id": "MUXex9ctTuDB"

--- a/quickstarts/Spatial_understanding.ipynb
+++ b/quickstarts/Spatial_understanding.ipynb
@@ -254,7 +254,6 @@
       },
       "outputs": [],
       "source": [
-        "import google.generativeai as genai\n",
         "from PIL import Image\n",
         "\n",
         "import io\n",


### PR DESCRIPTION
## Summary

Two notebooks in the repo have leftover `import google.generativeai as genai` lines from a prior partial migration. Both notebooks otherwise use the current `google-genai` SDK correctly via `from google import genai`, and neither notebook's `%pip install` cell installs `google-generativeai`. The result:

- On a **clean Colab kernel** (the documented run path) the dead imports raise `ModuleNotFoundError: No module named 'google.generativeai'`
- On a kernel where the legacy package happens to be pre-installed, the dead imports silently rebind the `genai` name to the deprecated SDK and shadow the working client

Either way, the dead lines are bugs. This PR removes them.

## Files

- **`quickstarts/Spatial_understanding.ipynb`** cell 19 — delete the single line `import google.generativeai as genai`. The other imports in the cell (`PIL.Image`, `io`, `os`, `requests`, `BytesIO`) are genuinely used downstream
- **`examples/Animated_Story_Video_Generation_gemini.ipynb`** cell 7 — delete the cell entirely. The cell's only content is the dead import

## Test plan

- Both notebooks now run top-to-bottom on a clean Colab kernel (no `ModuleNotFoundError`, no namespace shadowing).
- The downstream `genai.Client(...)` calls (Spatial_understanding cell 11, Animated_Story cells 14 and 17) continue to work because `from google import genai` is still imported.
- Diff is pure deletion — 12 lines removed, 0 added. No behavioural change beyond removing dead code.