### PR TITLE
Fix broken Contributing guide link in Template.ipynb

### DIFF
--- a/quickstarts/Template.ipynb
+++ b/quickstarts/Template.ipynb
@@ -245,7 +245,7 @@
         "id": "2V22fKegUtF9"
       },
       "source": [
-        "## Notebook style (also check the [Contributing guide](Contributing.mg))\n",
+        "## Notebook style (also check the [Contributing guide](https://github.com/google-gemini/cookbook/blob/main/CONTRIBUTING.md))\n",
         "\n",
         "* Include the collapsed license at the top (uses the Colab \"Form\" mode to hide the cells).\n",
         "* Save the notebook with the table of contents open.\n",


### PR DESCRIPTION
## Summary
The contributor-facing `quickstarts/Template.ipynb` linked the contributing guide as:

```
[Contributing guide](Contributing.mg)
```

This is broken two ways: the filename is misspelled (`.mg` → `.md`) and there is no such file next to the notebook (`CONTRIBUTING.md` lives at the repo root). Since Template.ipynb is the file contributors copy to start new notebooks, the dead link propagates.

Fixed to the same absolute GitHub URL the **same notebook** already uses elsewhere (for consistent rendering on GitHub + Colab):

```
[Contributing guide](https://github.com/google-gemini/cookbook/blob/main/CONTRIBUTING.md)
```

## Self-review
- Minimal diff (1 insertion, 1 deletion). Notebook still valid JSON.
- Matches the existing CONTRIBUTING.md link convention already in the file.