### PR TITLE
Fix case-sensitive links to Search_Grounding/Code_Execution notebooks

### DIFF
--- a/quickstarts/Get_started.ipynb
+++ b/quickstarts/Get_started.ipynb
@@ -2341,7 +2341,7 @@
       "source": [
         "Note that you should always display the grounding `rendered_content` when using search grounding.\n",
         "\n",
-        "Check out the [Search grounding ![image](https://storage.googleapis.com/generativeai-downloads/images/colab_icon16.png)](./Search_grounding.ipynb) dedicated guide for more details and examples."
+        "Check out the [Search grounding ![image](https://storage.googleapis.com/generativeai-downloads/images/colab_icon16.png)](./Search_Grounding.ipynb) dedicated guide for more details and examples."
       ]
     },
     {
@@ -2774,7 +2774,7 @@
         "\n",
         "[Code execution](https://ai.google.dev/gemini-api/docs/code-execution?lang=python) lets the model generate and execute Python code to answer complex questions.\n",
         "\n",
-        "You can find more examples in the [Code execution guide  ![image](https://storage.googleapis.com/generativeai-downloads/images/colab_icon16.png)](./Code_execution.ipynb)."
+        "You can find more examples in the [Code execution guide  ![image](https://storage.googleapis.com/generativeai-downloads/images/colab_icon16.png)](./Code_Execution.ipynb)."
       ]
     },
     {

--- a/quickstarts/Get_started_thinking.ipynb
+++ b/quickstarts/Get_started_thinking.ipynb
@@ -2174,7 +2174,7 @@
         "<a name=\"code_execution\"></a>\n",
         "### Solving a problem using the code execution tool\n",
         "\n",
-        "This example shows how to use the [code execution](./Code_execution.ipynb) tool to solve a problem. The model will generate the code and then execute it to get the final answer.\n",
+        "This example shows how to use the [code execution](./Code_Execution.ipynb) tool to solve a problem. The model will generate the code and then execute it to get the final answer.\n",
         "\n",
         "In this case, you are using the adaptive thinking_budget so the model will dynamically adjust the budget based on the complexity of the request.\n",
         "\n",


### PR DESCRIPTION
## Summary
Three cross-notebook links pointed at filenames with the wrong case. GitHub (and Linux/Colab file systems) are case-sensitive, so these links 404:

- `./Search_grounding.ipynb` → actual file is `Search_Grounding.ipynb`
- `./Code_execution.ipynb` → actual file is `Code_Execution.ipynb` (×2)

**Files:**
- `quickstarts/Get_started.ipynb` (2 links)
- `quickstarts/Get_started_thinking.ipynb` (1 link)

## Self-review
- Minimal diff (3 insertions, 3 deletions); only path casing changed, link text untouched.
- Verified targets exist: `quickstarts/Search_Grounding.ipynb`, `quickstarts/Code_Execution.ipynb`.
- Both notebooks still valid JSON.