### PR TITLE
Migrate Safety.ipynb to google-genai SDK (#446)

### DIFF
--- a/quickstarts/Safety.ipynb
+++ b/quickstarts/Safety.ipynb
@@ -130,7 +130,7 @@
         "\n",
         "Pick the prompt you want to use to test the safety filters settings. An examples could be `Write a list of 5 very rude things that I might say to the universe after stubbing my toe in the dark` which was previously tested and trigger the `HARM_CATEGORY_HARASSMENT` and `HARM_CATEGORY_DANGEROUS_CONTENT` categories.\n",
         "\n",
-        "The result returned by the [Model.generate_content](https://ai.google.dev/api/python/google/generativeai/GenerativeModel#generate_content) method is a [genai.protos.GenerateContentResponse](https://ai.google.dev/api/python/google/generativeai/types/GenerateContentResponse)."
+        "The result returned by the [client.models.generate_content](https://googleapis.github.io/python-genai/genai.html#genai.models.Models.generate_content) method is a [types.GenerateContentResponse](https://googleapis.github.io/python-genai/genai.html#genai.types.GenerateContentResponse)."
       ]
     },
     {
@@ -259,7 +259,7 @@
         "\n",
         "Depending on the scenario you are working with, it may be necessary to customize the safety filters behaviors to allow a certain degree of unsafety results.\n",
         "\n",
-        "To make this customization you must define a `safety_settings` dictionary as part of your `model.generate_content()` request. In the example below, all the filters are being set to do not block contents.\n",
+        "To make this customization you must define a `safety_settings` dictionary as part of your `client.models.generate_content()` request. In the example below, all the filters are being set to do not block contents.\n",
         "\n",
         "**Important:** To guarantee the Google commitment with the Responsible AI development and its [AI Principles](https://ai.google/responsibility/principles/), for some prompts Gemini will avoid generating the results even if you set all the filters to none."
       ]
@@ -412,17 +412,17 @@
         "\n",
         "You can refer to the safety settings using either their full name, or the aliases like `DANGEROUS` used in the Python code above.\n",
         "\n",
-        "Safety settings can be set in the [genai.GenerativeModel](https://ai.google.dev/api/python/google/generativeai/GenerativeModel) constructor.\n",
+        "Safety settings can be set in the [GenerateContentConfig](https://googleapis.github.io/python-genai/genai.html#genai.types.GenerateContentConfig) passed to a request.\n",
         "\n",
-        "* They can also be passed on each request to [GenerativeModel.generate_content](https://ai.google.dev/api/python/google/generativeai/GenerativeModel#generate_content) or [ChatSession.send_message](https://ai.google.dev/api/python/google/generativeai/ChatSession?hl=en#send_message).\n",
+        "* They are passed on each request to [client.models.generate_content](https://googleapis.github.io/python-genai/genai.html#genai.models.Models.generate_content) or [chat.send_message](https://googleapis.github.io/python-genai/genai.html#genai.chats.Chat.send_message).\n",
         "\n",
-        "- The [genai.protos.GenerateContentResponse](https://ai.google.dev/api/python/google/generativeai/protos/GenerateContentResponse) returns [SafetyRatings](https://ai.google.dev/api/python/google/generativeai/protos/SafetyRating) for the prompt in the [GenerateContentResponse.prompt_feedback](https://ai.google.dev/api/python/google/generativeai/protos/GenerateContentResponse/PromptFeedback), and for each [Candidate](https://ai.google.dev/api/python/google/generativeai/protos/Candidate) in the `safety_ratings` attribute.\n",
+        "- The [types.GenerateContentResponse](https://googleapis.github.io/python-genai/genai.html#genai.types.GenerateContentResponse) returns [SafetyRatings](https://googleapis.github.io/python-genai/genai.html#genai.types.SafetyRating) for the prompt in the [GenerateContentResponse.prompt_feedback](https://googleapis.github.io/python-genai/genai.html#genai.types.GenerateContentResponsePromptFeedback), and for each [Candidate](https://googleapis.github.io/python-genai/genai.html#genai.types.Candidate) in the `safety_ratings` attribute.\n",
         "\n",
-        "- A [genai.protos.SafetySetting](https://ai.google.dev/api/python/google/generativeai/protos/SafetySetting)  contains: [genai.protos.HarmCategory](https://ai.google.dev/api/python/google/generativeai/protos/HarmCategory) and a [genai.protos.HarmBlockThreshold](https://ai.google.dev/api/python/google/generativeai/types/HarmBlockThreshold)\n",
+        "- A [types.SafetySetting](https://googleapis.github.io/python-genai/genai.html#genai.types.SafetySetting) contains: [types.HarmCategory](https://googleapis.github.io/python-genai/genai.html#genai.types.HarmCategory) and a [types.HarmBlockThreshold](https://googleapis.github.io/python-genai/genai.html#genai.types.HarmBlockThreshold)\n",
         "\n",
-        "- A [genai.protos.SafetyRating](https://ai.google.dev/api/python/google/generativeai/protos/SafetyRating) contains a [HarmCategory](https://ai.google.dev/api/python/google/generativeai/protos/HarmCategory) and a [HarmProbability](https://ai.google.dev/api/python/google/generativeai/types/HarmProbability)\n",
+        "- A [types.SafetyRating](https://googleapis.github.io/python-genai/genai.html#genai.types.SafetyRating) contains a [HarmCategory](https://googleapis.github.io/python-genai/genai.html#genai.types.HarmCategory) and a [HarmProbability](https://googleapis.github.io/python-genai/genai.html#genai.types.HarmProbability)\n",
         "\n",
-        "The [genai.protos.HarmCategory](https://ai.google.dev/api/python/google/generativeai/protos/HarmCategory) enum includes both the categories for PaLM and Gemini models.\n",
+        "The [types.HarmCategory](https://googleapis.github.io/python-genai/genai.html#genai.types.HarmCategory) enum includes the categories supported by Gemini models.\n",
         "\n",
         "- When specifying enum values the SDK will accept the enum values themselves, or their integer or string representations.\n",
         "\n",


### PR DESCRIPTION
## Summary

Migrates the remaining `google-generativeai` (legacy SDK) references in `quickstarts/Safety.ipynb` to the new `google-genai` SDK, addressing #446.

The notebook's **code cells were already on the new SDK** (`genai.Client`, `client.models.generate_content`, `types.SafetySetting`). This PR updates the **explanatory markdown** that still referenced the old SDK:

- `Model.generate_content` / `model.generate_content()` → `client.models.generate_content`
- `genai.protos.*` → `google.genai.types.*` (`GenerateContentResponse`, `SafetySetting`, `HarmCategory`, `HarmBlockThreshold`, `SafetyRating`, `HarmProbability`, `Candidate`)
- `genai.GenerativeModel` constructor wording → `GenerateContentConfig`-based per-request settings
- `ChatSession.send_message` → `chat.send_message`
- Dropped the obsolete PaLM mention from the `HarmCategory` description
- Repointed all reference links from `ai.google.dev/api/python/google/generativeai/...` to the new `googleapis.github.io/python-genai/` docs

No code, outputs, or notebook structure were changed beyond what the SDK migration strictly requires.

## Verification

- Ran `python -m tensorflow_docs.tools.nblint --styles=google,tensorflow --arg=repo:google-gemini/cookbook --arg=branch:main quickstarts/Safety.ipynb` — introduces **no new failures**. The 4 navigation-button warnings also fail on `main` and are unrelated to this change; all content/style checks pass.
- 8 insertions / 8 deletions, markdown only.

 