### PR TITLE
docs: fix typographical and spelling errors in styleguide and quickstarts

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,11 +1,11 @@
 # Gemini Cookbook Python notebooks Style Guide
 
 # Introduction
-This style guide outlines the coding conventions for Python notebooks developped by the Gemini team.
+This style guide outlines the coding conventions for Python notebooks developed by the Gemini team.
 It's based on PEP 8, but with some modifications to address specific needs and
 preferences within our organization.
 
-This guide is mostly about the python content and the notebook, but don't forget to also review the markdown files. In particular, any new notebook should be referenced in the corresponding readmes (at folder level at least, and potentially the one on higer levels).
+This guide is mostly about the python content and the notebook, but don't forget to also review the markdown files. In particular, any new notebook should be referenced in the corresponding readmes (at folder level at least, and potentially the one on higher levels).
 
 # Key Principles
 * **Readability:** Code should be easy to understand for all developers. Since they are notebooks and aimed at teaching
@@ -24,7 +24,7 @@ This guide is mostly about the python content and the notebook, but don't forget
 * There are multiple SDKs to use the Gemini APIs. The correct and most recent one is the [Python genai](https://github.com/googleapis/python-genai) one.
     * `%pip install -U -q 'google-genai>=1.0.0'` is the right way to install the SDK. The version indicated should reflect the minimum version needed to use the features used in the notebook (1.0.0 by default or in doubt).
     * `from google import genai` is the right way to import the official SDK.
-    * `from google.genai import types` is the right way to uimport the types.
+    * `from google.genai import types` is the right way to import the types.
     * `import google.generativeai` is incorrect, this is the old one that was deprecated early 2025.
 
 
@@ -39,7 +39,7 @@ Most of the cookbook content is Colab notebooks, which are stored as Json.
 * Those cells can be either Markdown or python code (or sometimes bash in which case the code cell starts with `%%bash`).
 * The `outputs` do not have to be ignored, but if none of them changed while some code has, it might be a sign that the
   notebook has not been run to check that it works, in which case a warning should be raised;
-* Ideally we want the ouputs to be saved in the notebooks so that one can see what the code does without runnning it. The only exception is when the ouput is tooo large (it contains images or videos for ex.).
+* Ideally we want the outputs to be saved in the notebooks so that one can see what the code does without runnning it. The only exception is when the output is too large (it contains images or videos for ex.).
 * If the `execution_count` has changed to something else than `null`, it usually indicates that the formatting script has not
   been run. A warning should be raised, but only once per notebook. Be very clear that it means that the formatting script must be run, not that the outputs should be removed.
 

--- a/quickstarts/Image_out.ipynb
+++ b/quickstarts/Image_out.ipynb
@@ -46,7 +46,7 @@
         "id": "5a3a7f45ea5e"
       },
       "source": [
-        "### This guisde has been moved to [Get_Started_Nano_Banana.ipynb](./Get_Started_Nano_Banana.ipynb)\n",
+        "### This guide has been moved to [Get_Started_Nano_Banana.ipynb](./Get_Started_Nano_Banana.ipynb)\n",
         "Click here to open it directly in colab: <a target=\"_blank\" href=\"https://colab.research.google.com/github/google-gemini/cookbook/blob/main/quickstarts/Get_Started_Nano_Banana.ipynb\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" height=30/></a>"
       ]
     }


### PR DESCRIPTION
### Description
This Pull Request fixes several minor typographical and spelling errors found in the Python notebooks style guide and quickstart directory to improve documentation quality and readability.

### Changes Implemented:
1. **`.gemini/styleguide.md`**:
   - Fixed `developped` to `developed`.
   - Fixed `higer` to `higher`.
   - Fixed `uimport` to `import` for official SDK types.
   - Fixed `ouputs`/`ouput`/`tooo` to `outputs`/`output`/`too`.

2. **`quickstarts/Image_out.ipynb`**:
   - Fixed typo `guisde` to `guide` .