### PR TITLE
docs: fix broken notebook links in Get_started_Generate_Content

### DIFF
--- a/quickstarts/Get_started_Generate_Content.ipynb
+++ b/quickstarts/Get_started_Generate_Content.ipynb
@@ -608,7 +608,7 @@
         "<a name=\"multimodal_prompt\"></a>\n",
         "## Send multimodal prompts\n",
         "\n",
-        "Use Gemini model, a multimodal model that supports multimodal prompts. You can include text, [PDF documents ![image](https://storage.googleapis.com/generativeai-downloads/images/colab_icon16.png)](../quickstarts/PDF_Files.ipynb), images, [audio ![image](https://storage.googleapis.com/generativeai-downloads/images/colab_icon16.png)](../quickstarts/Audio.ipynb) and [videos ![image](https://storage.googleapis.com/generativeai-downloads/images/colab_icon16.png)](../quickstarts/Video.ipynb) in your prompt requests and get text or code responses. Check the [File API](#file_api) section below for more examples.\n",
+        "Use Gemini model, a multimodal model that supports multimodal prompts. You can include text, [PDF documents ![image](https://storage.googleapis.com/generativeai-downloads/images/colab_icon16.png)](../quickstarts/PDF_Files.ipynb), images, [audio ![image](https://storage.googleapis.com/generativeai-downloads/images/colab_icon16.png)](../quickstarts/Audio.ipynb) and [videos ![image](https://storage.googleapis.com/generativeai-downloads/images/colab_icon16.png)](../quickstarts/Video_understanding.ipynb) in your prompt requests and get text or code responses. Check the [File API](#file_api) section below for more examples.\n",
         "\n",
         "In this first example, you'll download an image from a specified URL, save it as a byte stream and then write those bytes to a local file named `jetpack.png`."
       ]
@@ -712,7 +712,7 @@
         "<a name=\"images\"></a>\n",
         "## Generate Images\n",
         "\n",
-        "Gemini can output images directly as part of a conversation using the [Image generation ![image](https://storage.googleapis.com/generativeai-downloads/images/colab_icon16.png)](./Image_out.ipynb) models (aka \"Nano-banana)."
+        "Gemini can output images directly as part of a conversation using the [Image generation ![image](https://storage.googleapis.com/generativeai-downloads/images/colab_icon16.png)](./Get_Started_Nano_Banana.ipynb) models (aka \"Nano-banana)."
       ]
     },
     {
@@ -1083,7 +1083,7 @@
         "id": "3w1PA0zTgXa7"
       },
       "source": [
-        "You can find more examples of controlled generation in the [dedicated notebook ![image](https://storage.googleapis.com/generativeai-downloads/images/colab_icon16.png)](./JSON.ipynb)."
+        "You can find more examples of controlled generation in the [dedicated notebook ![image](https://storage.googleapis.com/generativeai-downloads/images/colab_icon16.png)](./JSON_mode.ipynb)."
       ]
     },
     {
@@ -1281,7 +1281,7 @@
         "\n",
         "Now that you've seen how to send multimodal prompts, try uploading files to the API of different multimedia types. For small images, such as the previous multimodal example, you can point the Gemini model directly to a local file when providing a prompt. When you've larger files, many files, or files you don't want to send over and over again, you can use the [File Upload API](https://ai.google.dev/gemini-api/docs/files), and then pass the file by reference.\n",
         "\n",
-        "More examples and details in the [File API guide ![image](https://storage.googleapis.com/generativeai-downloads/images/colab_icon16.png)](./File-API.ipynb), or the guides dedicated to [Audio![image](https://storage.googleapis.com/generativeai-downloads/images/colab_icon16.png)](./Audio.ipynb), [Video![image](https://storage.googleapis.com/generativeai-downloads/images/colab_icon16.png)](./Video_understanding.ipynb) or [Image/Spatial![image](https://storage.googleapis.com/generativeai-downloads/images/colab_icon16.png)](./Spatial_understanding.ipynb) understanding."
+        "More examples and details in the [File API guide ![image](https://storage.googleapis.com/generativeai-downloads/images/colab_icon16.png)](./File_API.ipynb), or the guides dedicated to [Audio![image](https://storage.googleapis.com/generativeai-downloads/images/colab_icon16.png)](./Audio.ipynb), [Video![image](https://storage.googleapis.com/generativeai-downloads/images/colab_icon16.png)](./Video_understanding.ipynb) or [Image/Spatial![image](https://storage.googleapis.com/generativeai-downloads/images/colab_icon16.png)](./Spatial_understanding.ipynb) understanding."
       ]
     },
     {


### PR DESCRIPTION
Fixes internal links in `quickstarts/Get_started_Generate_Content.ipynb` that pointed to notebooks which have been renamed or removed. All corrected targets exist in the repo, and the notebook remains valid JSON.

| Broken link | Corrected to |
|---|---|
| `../quickstarts/Video.ipynb` | `../quickstarts/Video_understanding.ipynb` |
| `./Image_out.ipynb` | `./Get_Started_Nano_Banana.ipynb` (the cell describes it as "Image generation … aka Nano-banana") |
| `./JSON.ipynb` | `./JSON_mode.ipynb` |
| `./File-API.ipynb` | `./File_API.ipynb` |

### Verification
- Every corrected target was confirmed to exist on disk.
- The notebook still parses as valid JSON; the diff is limited to the four changed link lines.
- No overlap with other open PRs (#1273, #1276, #1177).