### PR TITLE
Fix malformed JSON in examples/gemini_google_adk_model_guardrails.ipynb

### DIFF
--- a/examples/gemini_google_adk_model_guardrails.ipynb
+++ b/examples/gemini_google_adk_model_guardrails.ipynb
@@ -555,7 +555,7 @@
         "\"\"\")\n",
         "\n",
         "safety_judge_agent = llm_agent.LlmAgent(\n",
-        "    model=\"gemini-3.5-flash-lite\", # @param [\"gemini-3.5-flash-lite\", \"gemini-2.5-flash\", \"gemini-2.5-pro\"]\n"
+        "    model=\"gemini-3.5-flash-lite\", # @param [\"gemini-3.5-flash-lite\", \"gemini-2.5-flash\", \"gemini-2.5-pro\"]\n",
         "    name=\"safety_judge\",\n",
         "    instruction=SAFETY_JUDGE_INSTRUCTION\n",
         ")\n",


### PR DESCRIPTION
The notebook `examples/gemini_google_adk_model_guardrails.ipynb` fails to parse as JSON and cannot be opened in Google Colab. One cell source array string element is missing its trailing comma (at char 20561, line 559). This PR adds the single missing comma so the file is valid JSON again, with no other content changes (+1 byte total). After the fix the notebook parses cleanly with json.load and opens in Colab.