### PR TITLE
chore: apply Zizmor security auto-fixes

### DIFF
--- a/.github/workflows/issue-metrics.yml
+++ b/.github/workflows/issue-metrics.yml
@@ -29,7 +29,7 @@ jobs:
           echo "last_month=$first_day..$last_day" >> "$GITHUB_ENV"
 
       - name: Run issue-metrics tool
-        uses: github/issue-metrics@4f29f34d9d831fe224cbc6c8a0d711415ebd01b1  # v3
+        uses: github/issue-metrics@4f29f34d9d831fe224cbc6c8a0d711415ebd01b1  # v3.1.1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEARCH_QUERY: 'repo:google-gemini/cookbook is:issue created:${{ env.last_month }} -reason:"not planned"'

--- a/.github/workflows/new_examples_links_in_table_of_content.yml
+++ b/.github/workflows/new_examples_links_in_table_of_content.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   new-example-links-in-examples-readme:
     runs-on: ubuntu-latest

--- a/.github/workflows/new_examples_links_in_table_of_content.yml
+++ b/.github/workflows/new_examples_links_in_table_of_content.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3.6.0
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           persist-credentials: false
       - name: Get Changed Files

--- a/.github/workflows/new_examples_links_in_table_of_content.yml
+++ b/.github/workflows/new_examples_links_in_table_of_content.yml
@@ -9,10 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3.6.0
+        with:
+          persist-credentials: false
       - name: Get Changed Files
         id: changed-files
-        uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c  # v45
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32  # v46.0.1
         with:
           files:  |
             examples/**/*.ipynb

--- a/.github/workflows/notebooks.yaml
+++ b/.github/workflows/notebooks.yaml
@@ -16,10 +16,11 @@ jobs:
     name: Notebook format
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         fetch-depth: 0  # Get *full* history
-    - uses: actions/setup-python@v4
+        persist-credentials: false
+    - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
     - name: Install tensorflow-docs
       run: python3 -m pip install -U git+https://github.com/tensorflow/docs
     - name: Fetch main branch
@@ -46,10 +47,11 @@ jobs:
     name: Notebook lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         fetch-depth: 0  # Get *full* history
-    - uses: actions/setup-python@v4
+        persist-credentials: false
+    - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
     - name: Install tensorflow-docs
       run: python3 -m pip install -U git+https://github.com/tensorflow/docs
     - name: Fetch main branch

--- a/.github/workflows/notebooks.yaml
+++ b/.github/workflows/notebooks.yaml
@@ -10,6 +10,9 @@ on:
   # Allow manual runs
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   # Format all notebooks.
   nbfmt:


### PR DESCRIPTION
I ran a quick Zizmor security scan on our GitHub workflows to tighten things up. This PR just applies the safe auto-fixes it suggested, like pinning our actions to commit hashes and securing checkout credentials.

I've dropped the full breakdown of the scan and the exact fixes below! 

Initial Audit Summary: 14 total findings (5 High, 6 Medium, 3 Low).
Auto-Fix Result: 10 fixes applied across 3 workflow files.
Post-Fix Active Findings: 4 remaining (requires manual mitigation).

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-e5630c88-7fff-6504-d399-b18d28d09d09"><h4 dir="ltr" style="line-height:1.5;text-align: justify;margin-top:18pt;margin-bottom:12pt;"><span style="font-size:12pt;font-family:Arial,sans-serif;color:#666666;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">1. Scan Results: Before Auto-Fix (14 Findings)</span></h4><div dir="ltr" style="margin-left:0pt;" align="left">
Workflow File | Line | Issue Type | Severity | Description & Guidance | Auto-Fix
-- | -- | -- | -- | -- | --
issue-metrics.yml | 32 | ref-version-mismatch | 🟡 Medium | github/issue-metrics@4f29f34d9d831fe224cbc6c8a0d711415ebd01b1 # v3 hash pin has mismatched version comment | ✅ Yes
new_examples_links_in_table_of_content.yml | 11 | artipacked | 🔵 Low | actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 does not set persist-credentials: false | ✅ Yes
new_examples_links_in_table_of_content.yml | 8 | excessive permissions | 🟡 Medium | Default permissions used due to no permissions: block | ❌ No
new_examples_links_in_table_of_content.yml | 15 | known-vulnerable-actions | 🔴 High | tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c has a known vulnerability | ✅ Yes
new_examples_links_in_table_of_content.yml | 12 | ref-version-mismatch | 🟡 Medium | actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3 hash pin has mismatched version comment | ✅ Yes
notebooks.yaml | 19 | artipacked | 🔵 Low | actions/checkout@v4 does not set persist-credentials: false | ✅ Yes
notebooks.yaml | 49 | artipacked | 🔵 Low | actions/checkout@v4 does not set persist-credentials: false | ✅ Yes
notebooks.yaml | 3 | excessive permissions | 🟡 Medium | Default permissions used due to no permissions: block | ❌ No
notebooks.yaml | 15 | excessive permissions | 🟡 Medium | Default permissions used due to no permissions: block | ❌ No
notebooks.yaml | 45 | excessive permissions | 🟡 Medium | Default permissions used due to no permissions: block | ❌ No
notebooks.yaml | 19 | unpinned-uses | 🔴 High | actions/checkout@v4 not pinned to a hash | ✅ Yes
notebooks.yaml | 22 | unpinned-uses | 🔴 High | actions/setup-python@v4 not pinned to a hash | ✅ Yes
notebooks.yaml | 49 | unpinned-uses | 🔴 High | actions/checkout@v4 not pinned to a hash | ✅ Yes
notebooks.yaml | 52 | unpinned-uses | 🔴 High | actions/setup-python@v4 not pinned to a hash | ✅ Yes

</div></b>

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-d5414156-7fff-a9c2-97d0-678b5b8055bd"><h4 dir="ltr" style="line-height:1.5;text-align: justify;margin-top:18pt;margin-bottom:12pt;"><span style="font-size:12pt;font-family:Arial,sans-serif;color:#666666;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">2. Scan Results: After Auto-Fix (4 Findings Remaining)</span></h4><div dir="ltr" style="margin-left:0pt;" align="left">
Workflow File | Line | Issue Type | Severity | Description & Guidance | Auto-Fix
-- | -- | -- | -- | -- | --
new_examples_links_in_table_of_content.yml | 8 | excessive permissions | 🟡 Medium | Default permissions used due to no permissions: block | ❌ No
notebooks.yaml | 3 | excessive permissions | 🟡 Medium | Default permissions used due to no permissions: block | ❌ No
notebooks.yaml | 15 | excessive permissions | 🟡 Medium | Default permissions used due to no permissions: block | ❌ No
notebooks.yaml | 46 | excessive permissions | 🟡 Medium | Default permissions used due to no permissions: block | ❌ No

</div></b>

