### PR TITLE
feat(testing): add dynamic model override support to nb_tester suite

### DIFF
--- a/tools/nb_tester/Design.md
+++ b/tools/nb_tester/Design.md
@@ -59,8 +59,41 @@ flowchart TD
 
 ---
 
-## 4. Observability & Developer Experience
+## 4. In-Memory Dynamic Model Overriding (`--model <name>`)
 
-- **Config Centralization**: All models (`SECURITY_AUDITOR_MODEL`, `OUTPUT_JUDGE_MODEL`, `GROUNDED_VERIFIER_MODEL`), timeouts, and thresholds reside in `config.py`.
+To test entire test suites or individual tutorials against candidate models (e.g. `gemini-3.7-flash`, `gemini-3.1-pro-preview`) without permanently modifying repository notebooks, `nb_tester` integrates an in-memory AST and regex transformer:
+
+```
+                      ┌─────────────────────────────────────┐
+                      │   Original Notebook (.ipynb file)   │
+                      │  (MODEL_ID = "gemini-2.5-flash")    │
+                      └──────────────────┬──────────────────┘
+                                         │ (Deepcopy in memory)
+                                         ▼
+                      ┌─────────────────────────────────────┐
+                      │    ModelOverrideTransformer        │
+                      │  - Rewrites assignments to MODEL_ID │
+                      │  - Rewrites Colab @param dropdowns  │
+                      │  - Generates kernel preamble        │
+                      └──────────────────┬──────────────────┘
+                                         │
+                                         ▼
+                      ┌─────────────────────────────────────┐
+                      │    Ephemeral IPython Kernel         │
+                      │  (MODEL_ID = "<override_model>")    │
+                      │  (os.environ["MODEL_ID"] = "...")   │
+                      └─────────────────────────────────────┘
+```
+
+### Safety & Integrity Guarantees:
+- **Zero Disk Mutation**: All AST transformations occur exclusively on in-memory `NotebookNode` copies. Original `.ipynb` files on disk are never altered.
+- **Full Assignment Coverage**: Matches single quotes, double quotes, Colab `# @param` forms, type annotations, and chained assignments.
+- **Preamble Injection**: Injects `MODEL_ID` and environment variables before cell 0 to ensure immediate environment readiness.
+
+---
+
+## 5. Observability & Developer Experience
+
+- **Config Centralization**: All models (`SECURITY_AUDITOR_MODEL`, `OUTPUT_JUDGE_MODEL`, `GROUNDED_VERIFIER_MODEL`, `OVERRIDE_MODEL`), timeouts, and thresholds reside in `config.py`.
 - **LLM Observability**: Every single call to Gemini logs the prompt, generation parameters, response, and duration.
 - **Dry-Run Capability**: Every feature can be validated using `--dry-run` without touching network or filesystem state.

--- a/tools/nb_tester/README.md
+++ b/tools/nb_tester/README.md
@@ -17,11 +17,13 @@ An automated, security-gated test runner and semantic regression evaluator desig
    - For real-time and time-evolving queries (e.g. sports scores, weather, current events), uses Gemini with the Google Search tool to double-check that new answers are factually true today.
 4. **📋 Declarative Rules & Exception Registry (`rules/default_rules.yaml`)**:
    - Easily configure cell-level actions (e.g. skipping interactive `input()` cells) and per-notebook timeouts.
-5. **📊 CI & Pull Request Integration**:
+5. **🎯 Dynamic Model Identifier Override (`--model <name>`)**:
+   - Test the entire cookbook (or specific notebooks) against candidate or pre-release models (e.g. `gemini-3.7-flash`, `gemini-3.1-pro-preview`) by dynamically overriding `MODEL_ID` in memory across all executed cells without touching disk.
+6. **📊 CI & Pull Request Integration**:
    - Generates persistent JSON reports under `reports/` and auto-appends formatted Markdown tables to `$GITHUB_STEP_SUMMARY`.
    - Returns clean exit codes (`0` on pass, `1` on failure) for automated gating.
-6. **🔍 Dry-Run Mode**:
-   - Test rule configurations, AST checks, and syntax parsing without altering files, spinning up kernels, or consuming API tokens.
+7. **🔍 Dry-Run Mode**:
+   - Test rule configurations, AST checks, model overrides, and syntax parsing without altering files, spinning up kernels, or consuming API tokens.
 
 ---
 
@@ -48,7 +50,16 @@ python3 -m tools.nb_tester.cli --notebook quickstarts/Counting_Tokens.ipynb
 python3 -m tools.nb_tester.cli --changed
 ```
 
-### 5. Run Full Suite in Parallel
+### 5. Test Notebooks with Dynamic Model Override
+```bash
+# Run a specific quickstart against a candidate/preview model
+python3 -m tools.nb_tester.cli --notebook quickstarts/Get_started_thinking.ipynb --model gemini-3.1-pro-preview
+
+# Run all quickstarts with model override in parallel
+python3 -m tools.nb_tester.cli --all --model gemini-3.7-flash --workers 4
+```
+
+### 6. Run Full Suite in Parallel
 ```bash
 python3 -m tools.nb_tester.cli --all --workers 4
 ```
@@ -90,6 +101,7 @@ tools/nb_tester/
 ├── security_scanner.py   # Level 1: Deterministic AST & regex scanner
 ├── ai_security_auditor.py# Level 2: Gemini AI Semantic Security Auditor
 ├── rules.py              # Declarative rules engine and matcher
+├── model_override.py     # In-memory MODEL_ID override transformer & preamble injector
 ├── executor.py           # nbclient kernel executor with in-memory Colab mock
 ├── comparator.py         # Output snapshot extractor and strategy router
 ├── llm_judge.py          # Level 3: Semantic output regression judge

--- a/tools/nb_tester/__init__.py
+++ b/tools/nb_tester/__init__.py
@@ -19,4 +19,7 @@ This package provides security scanning, isolated kernel execution,
 output regression comparison with Gemini LLM judge, and Google Search Grounding verification.
 """
 
-__version__ = "1.0.0"
+from .model_override import ModelOverrideTransformer
+
+__version__ = "1.1.0"
+__all__ = ["ModelOverrideTransformer"]

--- a/tools/nb_tester/cli.py
+++ b/tools/nb_tester/cli.py
@@ -371,6 +371,8 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument("--dry-run", action="store_true", help="Simulate tests without altering state or invoking kernel.")
     parser.add_argument("--security-only", action="store_true", help="Run static & AI security audits only.")
     parser.add_argument("--skip-ai-judge", action="store_true", help="Skip semantic AI output diffing.")
+    parser.add_argument("--model", "-m", type=str, help="Override MODEL_ID with a specific Gemini model name across all executed notebook cells.")
+    parser.add_argument("--override-model", type=str, dest="model", help=argparse.SUPPRESS)
     parser.add_argument("--workers", "-w", type=int, default=1, help="Number of concurrent worker threads.")
     parser.add_argument("--rules-file", type=str, help="Path to custom YAML rules file.")
     parser.add_argument("--output-json", type=str, help="Custom output path for JSON test report.")
@@ -383,11 +385,14 @@ def main(argv: Optional[List[str]] = None) -> int:
     config.SECURITY_ONLY = args.security_only
     config.SKIP_AI_JUDGE = args.skip_ai_judge
     config.VERBOSE = args.verbose
+    config.OVERRIDE_MODEL = args.model
     if args.rules_file:
         config.DEFAULT_RULES_PATH = pathlib.Path(args.rules_file).resolve()
 
     setup_logger(verbose=args.verbose)
     logger.info("🔧 Initializing Notebook Testing & Regression Suite...")
+    if config.OVERRIDE_MODEL:
+        logger.info(f"🎯 Model Override Active: enforcing MODEL_ID = '{config.OVERRIDE_MODEL}' across all notebooks")
 
     # Validate configuration
     issues = config.validate()

--- a/tools/nb_tester/config.py
+++ b/tools/nb_tester/config.py
@@ -98,6 +98,7 @@ class TesterConfig:
     VERBOSE: bool = False
     SKIP_AI_JUDGE: bool = False
     SECURITY_ONLY: bool = False
+    OVERRIDE_MODEL: Optional[str] = None
 
     def get_api_key(self) -> Optional[str]:
         """

--- a/tools/nb_tester/executor.py
+++ b/tools/nb_tester/executor.py
@@ -47,6 +47,7 @@ from nbclient.exceptions import CellTimeoutError, CellExecutionError
 from .config import GLOBAL_CONFIG, TesterConfig
 from .logger import logger
 from .rules import RulesEngine, NotebookRuleSet, CellRule
+from .model_override import ModelOverrideTransformer
 
 
 @dataclass
@@ -89,6 +90,7 @@ class NotebookExecutor:
         """
         self.config = config or GLOBAL_CONFIG
         self.rules_engine = rules_engine or RulesEngine(config=self.config)
+        self.model_transformer = ModelOverrideTransformer(override_model=self.config.OVERRIDE_MODEL)
 
     def execute_notebook(
         self,
@@ -165,9 +167,14 @@ class NotebookExecutor:
                         cell.source,
                         flags=re.MULTILINE
                     )
-        
+
+        # Apply Model Override across all cells if active
+        if self.model_transformer.is_active():
+            self.model_transformer.transform_notebook(exec_nb, notebook_path=rel_path)
+
         # Inject Colab Mock Preamble
         api_key = self.config.get_api_key() or ""
+        override_preamble = self.model_transformer.generate_preamble_code()
         mock_source = (
             "import sys, os, pathlib\n"
             "from unittest.mock import MagicMock\n"
@@ -176,6 +183,7 @@ class NotebookExecutor:
             "sys.modules['google.colab'] = _mock_colab\n"
             "sys.modules['google.colab.userdata'] = _mock_colab.userdata\n"
             f"os.environ['GEMINI_API_KEY'] = {api_key!r}\n"
+            f"{override_preamble}"
             "# Automatically touch flag files for bash/REST notebooks\n"
             "try:\n"
             "    pathlib.Path('I_am_aware_that_veo_is_a_paid_feature').touch(exist_ok=True)\n"
@@ -315,11 +323,15 @@ class NotebookExecutor:
         rule_set: NotebookRuleSet
     ) -> NotebookExecutionResult:
         """Simulates execution for dry-run verification."""
+        sim_nb = copy.deepcopy(nb)
+        if self.model_transformer.is_active():
+            self.model_transformer.transform_notebook(sim_nb, notebook_path=rel_path)
+
         records = []
         code_count = 0
         skip_count = 0
 
-        for i, cell in enumerate(nb.cells):
+        for i, cell in enumerate(sim_nb.cells):
             if cell.cell_type == "code":
                 code_count += 1
                 source = cell.source or ""
@@ -354,5 +366,5 @@ class NotebookExecutor:
             skipped_cells_count=skip_count,
             first_error_message=None,
             cell_records=records,
-            executed_nb_copy=nb
+            executed_nb_copy=sim_nb
         )

--- a/tools/nb_tester/model_override.py
+++ b/tools/nb_tester/model_override.py
@@ -1,0 +1,174 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Dynamic Model Identifier Override Module for Notebook Testing Suite.
+
+This module provides in-memory AST and pattern transformation capabilities to
+override MODEL_ID (and related model assignment variables) across all code cells
+in Jupyter Notebooks during testing without modifying notebook files on disk.
+
+Problem & Motivation:
+When validating the Gemini API Cookbook against a specific Gemini model version
+(e.g. a newly launched model like gemini-3.7-flash, a flagship preview like
+gemini-3.1-pro-preview, or an early-access/canary model), developers and CI
+pipelines need to run the entire notebook test suite with that specific model
+consistently applied, rather than relying on whatever default model was statically
+hardcoded in each individual notebook.
+
+Key Capabilities:
+1. In-Memory Transformation: Transforms notebook code cells in kernel memory only,
+   leaving repository .ipynb files completely untouched.
+2. Comprehensive Pattern Matching: Handles all common Python assignment patterns for
+   model constants, including:
+   - Simple string assignments: MODEL_ID = "gemini-2.5-flash"
+   - Colab @param dropdown forms: MODEL_ID = "gemini-2.5-flash" # @param [...]
+   - Single-quoted strings: MODEL_ID = 'gemini-1.5-pro'
+   - Chained multi-variable assignments: EMBEDDING_MODEL_ID = MODEL_ID = "..."
+   - Type-annotated assignments: MODEL_ID: str = "..."
+   - Indented assignments inside setup functions or blocks.
+   - Related model constants: MODEL_NAME, model_id.
+3. Preamble Injection: Injects MODEL_ID = "<override_model>" and
+   os.environ["MODEL_ID"] = "<override_model>" into the isolated kernel
+   preamble so that initial environment state and downstream helpers resolve to the
+   overridden model immediately.
+4. Detailed Audit Logging: Logs every transformed cell index, showing the original
+   model string and the newly applied override model for full visibility.
+
+Use Cases:
+1. Testing the whole cookbook against a new Gemini release (e.g. nb_tester --all --model gemini-3.7-flash).
+2. Testing specific quickstarts with pre-release or experimental models (e.g. nb_tester -n quickstarts/Get_started_thinking.ipynb --model gemini-3.1-pro-preview).
+3. Running dry-run audits to inspect which notebooks would be affected by a model migration.
+"""
+
+import re
+from typing import Optional, Tuple
+import nbformat
+
+from .logger import logger
+
+
+class ModelOverrideTransformer:
+    """Transforms notebook cells in-memory to override MODEL_ID assignments."""
+
+    # Matches assignments to MODEL_ID, MODEL_NAME, model_id with string literals or templates
+    MODEL_ASSIGNMENT_PATTERN = re.compile(
+        r"^(\s*(?:[\w\.]+\s*=\s*)*(?:MODEL_ID|MODEL_NAME|model_id)(?:\s*:\s*[^=]+)?\s*=\s*)(?:\"[^\"]*\"|\'[^\']*\'|[\w\.\-]+)(.*)$",
+        re.MULTILINE
+    )
+
+    def __init__(self, override_model: Optional[str] = None):
+        """
+        Initializes the ModelOverrideTransformer.
+
+        Args:
+            override_model: The Gemini model identifier to enforce across all notebook cells.
+        """
+        self.override_model = override_model.strip() if override_model else None
+
+    def is_active(self) -> bool:
+        """
+        Checks if model overriding is currently enabled.
+
+        Returns:
+            True if an override model string is configured, False otherwise.
+        """
+        return bool(self.override_model)
+
+    def transform_cell_source(self, source: str, cell_index: int = 0) -> Tuple[str, int]:
+        """
+        Transforms a single code cell's source string to replace model assignments.
+
+        Args:
+            source: Raw Python source code of the cell.
+            cell_index: 0-based cell index for logging context.
+
+        Returns:
+            Tuple of (transformed_source_code, number_of_replacements_made).
+        """
+        if not self.is_active() or not source:
+            return source, 0
+
+        replacements = 0
+
+        def _replace_match(match: re.Match) -> str:
+            nonlocal replacements
+            replacements += 1
+            prefix = match.group(1)
+            suffix = match.group(2)
+            original_match = match.group(0).strip()
+            new_line = f'{prefix}"{self.override_model}"{suffix}'
+            logger.info(
+                f"  🔄 [Model Override] Cell {cell_index}: "
+                f"'{original_match}' -> '{new_line.strip()}'"
+            )
+            return new_line
+
+        transformed = self.MODEL_ASSIGNMENT_PATTERN.sub(_replace_match, source)
+        return transformed, replacements
+
+    def transform_notebook(
+        self,
+        nb: nbformat.NotebookNode,
+        notebook_path: str = ""
+    ) -> Tuple[nbformat.NotebookNode, int]:
+        """
+        Applies model override transformations across all code cells of an in-memory notebook.
+
+        Args:
+            nb: In-memory NotebookNode object (will be modified in-place).
+            notebook_path: Path/name of the notebook for logging context.
+
+        Returns:
+            Tuple of (modified_notebook, total_replacements_applied).
+        """
+        if not self.is_active():
+            return nb, 0
+
+        total_overrides = 0
+        for idx, cell in enumerate(nb.cells):
+            if cell.cell_type == "code" and cell.source:
+                new_source, count = self.transform_cell_source(cell.source, cell_index=idx)
+                if count > 0:
+                    cell.source = new_source
+                    total_overrides += count
+
+        if total_overrides > 0:
+            logger.info(
+                f"🎯 Applied {total_overrides} model override(s) in '{notebook_path}' -> {self.override_model}"
+            )
+        else:
+            logger.debug(
+                f"ℹ️ No explicit MODEL_ID assignments found to override in '{notebook_path}'."
+            )
+
+        return nb, total_overrides
+
+    def generate_preamble_code(self) -> str:
+        """
+        Generates Python code to be injected into the kernel mock preamble for model override.
+
+        Returns:
+            Python code snippet declaring MODEL_ID and environment variables.
+        """
+        if not self.is_active():
+            return ""
+
+        return (
+            f"# Injected by ModelOverrideTransformer\n"
+            f"MODEL_ID = {self.override_model!r}\n"
+            f"MODEL_NAME = {self.override_model!r}\n"
+            f"model_id = {self.override_model!r}\n"
+            f"os.environ['MODEL_ID'] = {self.override_model!r}\n"
+        )

--- a/tools/nb_tester/reporter.py
+++ b/tools/nb_tester/reporter.py
@@ -71,6 +71,7 @@ class SuiteReport:
     skipped_count: int
     dry_run: bool
     total_duration_sec: float
+    override_model: Optional[str] = None
     notebook_reports: List[SingleNotebookReport] = field(default_factory=list)
 
 
@@ -114,6 +115,7 @@ class TestReporter:
             skipped_count=skipped,
             dry_run=self.config.DRY_RUN,
             total_duration_sec=round(total_duration, 2),
+            override_model=self.config.OVERRIDE_MODEL,
             notebook_reports=notebook_reports
         )
 
@@ -155,10 +157,12 @@ class TestReporter:
         if not step_summary_path:
             return
 
+        model_info = f"**Model Override:** `{suite_report.override_model}` | " if suite_report.override_model else ""
         md_lines = [
             f"# 🧪 Gemini API Cookbook Notebook Test Report",
             f"",
             f"**Status:** {'✅ PASSED' if suite_report.failed_count == 0 else '❌ FAILED'} | "
+            f"{model_info}"
             f"**Total:** {suite_report.total_notebooks} | "
             f"**Passed:** {suite_report.passed_count} | "
             f"**Failed:** {suite_report.failed_count} | "
@@ -197,6 +201,8 @@ class TestReporter:
         """
         logger.info("\n" + "=" * 80)
         logger.info(f"📊 TEST SUITE SUMMARY (Duration: {suite_report.total_duration_sec}s)")
+        if suite_report.override_model:
+            logger.info(f"🎯 Target Model Override: {suite_report.override_model}")
         logger.info(
             f"Total: {suite_report.total_notebooks} | "
             f"Passed: {suite_report.passed_count} | "


### PR DESCRIPTION
## Summary

This PR adds dynamic model identifier override support to the `nb_tester` test runner suite.

Developers and CI pipelines can now evaluate the entire Gemini API Cookbook (or specific targeted notebooks) against candidate or pre-release models (such as `gemini-3.7-flash`, `gemini-3.1-pro-preview`, or early-access models) by supplying the `--model` / `-m` flag.

### Key Changes
- **In-Memory Transformation (`tools/nb_tester/model_override.py`)**: Introduces `ModelOverrideTransformer` which dynamically parses and rewrites assignments to `MODEL_ID` (including double-quoted strings, single-quoted strings, Colab `# @param` dropdown forms, and type-annotated definitions) exclusively in kernel memory without mutating repository `.ipynb` files on disk.
- **Mock Preamble Injection**: Injects `MODEL_ID = '<override_model>'` and `os.environ['MODEL_ID'] = '<override_model>'` into cell 0 of the isolated IPython kernel.
- **CLI Options (`tools/nb_tester/cli.py`)**: Adds `--model` / `-m` (and `--override-model`) arguments.
- **Report & Summary Tracking (`tools/nb_tester/reporter.py`)**: Captures active model override in JSON test reports, ``, and terminal summaries.
- **Documentation**: Updates `tools/nb_tester/README.md` and `tools/nb_tester/Design.md` with architecture details and usage instructions.

### Usage Example
```bash
# Run a specific notebook with model override
python3 -m tools.nb_tester.cli --notebook quickstarts/Get_started_thinking.ipynb --model gemini-3.1-pro-preview

# Run all quickstarts against a candidate model in parallel
python3 -m tools.nb_tester.cli --all --model gemini-3.7-flash --workers 4
```

### Verification
- Ran comprehensive unit tests on `ModelOverrideTransformer` (9/9 tests passed).
- Verified dry-run execution on multiple notebooks (`Get_Started_Nano_Banana.ipynb`, `Get_started_thinking.ipynb`, `Counting_Tokens.ipynb`).
- Verified live end-to-end kernel execution, Gemini AI security audit, and semantic output judge on `quickstarts/Enum.ipynb` with `--model gemini-3.7-flash` (Passed with 0 regressions).